### PR TITLE
fix(mapper): UserMapper selectAll 쿼리 태그 누락 수정

### DIFF
--- a/backend/src/main/resources/mapper/user/UserMapper.xml
+++ b/backend/src/main/resources/mapper/user/UserMapper.xml
@@ -11,6 +11,7 @@
     SELECT * FROM users WHERE id = #{id} AND deleted_at IS NULL
   </select>
 
+  <select id="selectAll" resultType="User">
     SELECT * FROM users WHERE deleted_at IS NULL ORDER BY id
   </select>
 


### PR DESCRIPTION
## 🚀 작업 배경

`UserMapper.xml` 파일에서 `selectAll` 쿼리의 여는 태그(`<select>`)가 누락되어 애플리케이션 실행 시 XML 파싱 에러가 발생하고 백엔드 서버가 다운되었습니다. (502 error)

---

## 🛠️ 주요 변경 사항

- `UserMapper.xml`: `selectAll` 쿼리에 누락된 `<select id="selectAll" resultType="User">` 태그를 추가했습니다.

---

## 🔗 전달 사항

- 빠른 검토 부탁드립니다.