### PR TITLE
refactor(dashboard): StudyId에 대해 직접 도메인 객체를 통해 접근하도록 변경

### DIFF
--- a/backend/src/main/java/com/ssafy/dash/dashboard/presentation/DashboardController.java
+++ b/backend/src/main/java/com/ssafy/dash/dashboard/presentation/DashboardController.java
@@ -27,7 +27,7 @@ public class DashboardController {
         
         if (studyId != null) {
              boolean isAdmin = oauthUser.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
-             Long userStudyId = oauthUser.getStudyId();
+             Long userStudyId = oauthUser.getUser().getStudyId();
 
              // Study ID가 같으면 허용, 다르면 관리자만 허용
              if (!isAdmin && (userStudyId == null || !userStudyId.equals(studyId))) {
@@ -46,7 +46,7 @@ public class DashboardController {
         
         if (studyId != null) {
              boolean isAdmin = oauthUser.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
-             Long userStudyId = oauthUser.getStudyId();
+             Long userStudyId = oauthUser.getUser().getStudyId();
 
              if (!isAdmin && (userStudyId == null || !userStudyId.equals(studyId))) {
                  return ResponseEntity.status(403).build();


### PR DESCRIPTION
## 🚀 작업 배경

`CustomOAuth2User`는 보안 인증용 래퍼 클래스인데, 도메인 필드(StudyId 등)를 하나씩 위임하는 메서드로 만들다 보면 클래스가 점점 비대해지고 도메인 로직과 보안 로직이 섞이게 됩니다.

`CustomOAuth2User`는 이미 `getUser()`를 통해 도메인 객체를 제공하고 있습니다. 따라서, 컨트롤러에서 억지로 래퍼 메서드를 호출하지 말고, 직접 도메인 객체를 통해 접근하는 것이 훨씬 명확하고 유지보수하기 좋다고 판단합니다.

---

## 🛠️ 주요 변경 사항

- [x] 백엔드 빌드 에러를 해결했습니다.