### PR TITLE
fix: 대시보드 풀이 기록 미표시 수정 및 채팅 날짜 구분선 추가

### DIFF
--- a/frontend/src/components/social/DirectMessageModal.vue
+++ b/frontend/src/components/social/DirectMessageModal.vue
@@ -156,6 +156,8 @@ const showDateSeparator = (index, msgs) => {
     
     return currentMsgDate !== prevMsgDate;
 };
+let pollInterval;
+
 onMounted(() => {
     fetchMessages();
     pollInterval = setInterval(fetchMessages, 3000); // 3초마다 새 메시지 폴링

--- a/frontend/src/components/social/DirectMessageModal.vue
+++ b/frontend/src/components/social/DirectMessageModal.vue
@@ -25,20 +25,28 @@
             <div class="flex-1 overflow-y-auto p-4 space-y-4 bg-slate-50" ref="messagesContainer">
                 <div v-if="loading" class="flex justify-center py-10"><Loader2 class="animate-spin text-brand-500"/></div>
                 <template v-else>
-                    <div 
-                        v-for="msg in messages" 
-                        :key="msg.id" 
-                        class="flex flex-col"
-                        :class="msg.isMine ? 'items-end' : 'items-start'"
-                    >
-                         <div 
-                            class="max-w-[70%] px-4 py-2.5 rounded-2xl text-sm font-medium shadow-sm leading-relaxed whitespace-pre-wrap"
-                            :class="msg.isMine ? 'bg-brand-500 text-white rounded-tr-sm' : 'bg-white text-slate-700 border border-slate-200 rounded-tl-sm'"
-                         >
-                            {{ msg.content }}
-                         </div>
-                         <span class="text-[10px] text-slate-400 mt-1 px-1">{{ formatTime(msg.createdAt) }}</span>
-                    </div>
+                    <template v-for="(msg, index) in messages" :key="msg.id">
+                        <!-- Date Separator -->
+                        <div v-if="showDateSeparator(index, messages)" class="w-full flex justify-center my-6">
+                            <span class="text-xs font-bold text-slate-600 bg-slate-200/80 px-4 py-1.5 rounded-full border border-slate-300/50 shadow-sm">
+                                {{ formatDate(msg.createdAt) }}
+                            </span>
+                        </div>
+
+                        <!-- Message Item -->
+                        <div 
+                            class="flex flex-col"
+                            :class="msg.isMine ? 'items-end' : 'items-start'"
+                        >
+                             <div 
+                                class="max-w-[70%] px-4 py-2.5 rounded-2xl text-sm font-medium shadow-sm leading-relaxed whitespace-pre-wrap"
+                                :class="msg.isMine ? 'bg-brand-500 text-white rounded-tr-sm' : 'bg-white text-slate-700 border border-slate-200 rounded-tl-sm'"
+                             >
+                                {{ msg.content }}
+                             </div>
+                             <span class="text-[10px] text-slate-400 mt-1 px-1">{{ formatTime(msg.createdAt) }}</span>
+                        </div>
+                    </template>
                 </template>
             </div>
             
@@ -130,8 +138,24 @@ const formatTime = (iso) => {
     return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 };
 
-let pollInterval;
+const formatDate = (iso) => {
+    const d = new Date(iso);
+    return d.toLocaleDateString('ko-KR', { 
+        year: 'numeric', 
+        month: 'long', 
+        day: 'numeric', 
+        weekday: 'long' 
+    });
+};
 
+const showDateSeparator = (index, msgs) => {
+    if (index === 0) return true;
+    
+    const currentMsgDate = new Date(msgs[index].createdAt).toLocaleDateString();
+    const prevMsgDate = new Date(msgs[index - 1].createdAt).toLocaleDateString();
+    
+    return currentMsgDate !== prevMsgDate;
+};
 onMounted(() => {
     fetchMessages();
     pollInterval = setInterval(fetchMessages, 3000); // 3초마다 새 메시지 폴링

--- a/frontend/src/views/dashboard/DashboardView.vue
+++ b/frontend/src/views/dashboard/DashboardView.vue
@@ -483,7 +483,7 @@ const props = defineProps({
     }
 });
 
-const { user } = useAuth();
+const { user, refresh } = useAuth();
 const router = useRouter();
 const records = ref([]);
 const studyData = ref(null);
@@ -889,14 +889,16 @@ const handleAcornUsed = () => {
 };
 
 onMounted(async () => {
-  try {
-      // 1. 사용자 기록 가져오기
-      try {
-          const recordsRes = await dashboardApi.getRecords(currentStudyId.value);
-          records.value = recordsRes.data;
-      } catch(e) {
-          console.error('Records Load Error:', e);
-      }
+    try {
+        await refresh();
+
+        // 1. 사용자 기록 가져오기
+        try {
+            const recordsRes = await dashboardApi.getRecords(currentStudyId.value);
+            records.value = recordsRes.data;
+        } catch(e) {
+            console.error('Records Load Error:', e);
+        }
       
       // 2. 태그 통계 가져오기
       try {


### PR DESCRIPTION
## 🚀 작업 배경

1. 스터디 이동 직후 대시보드에 진입하면 유저 정보가 갱신되지 않아 **알고리즘 풀이 기록**이 보이지 않는 문제가 있었습니다.
2. 채팅 내에서 메시지가 날짜별로 구분되지 않아 언제 보낸 메시지인지 파악하기 어려운 불편함이 있었습니다.

---

## 🛠️ 주요 변경 사항

- [X] 페이지 진입(onMounted) 시 refresh()를 호출하여 최신 유저 정보(스터디 ID)를 강제로 동기화했습니다.
- [X] 메시지 리스트에 날짜 구분선(Date Separator) 기능을 추가했습니다.