### PR TITLE
fix: Watchtower GHCR 인증을 위한 docker config 마운트 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       - DOCKER_API_VERSION=1.44
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - /home/w-pi/.docker/config.json:/config.json:ro
     command: --interval 30 --cleanup
     networks:
       - dash-network
@@ -88,6 +89,7 @@ services:
 
 volumes:
   mysql_data:
+
 
 networks:
   dash-network:


### PR DESCRIPTION
## 🚀 작업 배경

Watchtower가 GHCR(GitHub Container Registry)에서 최신 Docker 이미지를 자동으로 pull하지 못하는 문제가 발생했습니다. GHCR이 private registry로 설정되어 있어 인증 정보 없이는 이미지에 접근할 수 없었습니다.

---

## 🛠️ 주요 변경 사항

- [X] Watchtower 컨테이너에 Docker 인증 정보(config.json) 볼륨 마운트 추가
- [X] 보안을 위해 읽기 전용(:ro) 모드로 마운트
- [X] 이를 통해 Watchtower가 private GHCR에서 이미지를 pull할 수 있도록 설정