### PR TITLE
feat: 스터디 스트릭, 배틀 기능 수정, 프론트 중복 요소 제거

### DIFF
--- a/backend/src/main/java/com/ssafy/dash/algorithm/domain/AlgorithmRecordRepository.java
+++ b/backend/src/main/java/com/ssafy/dash/algorithm/domain/AlgorithmRecordRepository.java
@@ -37,4 +37,6 @@ public interface AlgorithmRecordRepository {
     List<com.ssafy.dash.dashboard.application.dto.response.HeatmapRawData> findHeatmapDataByUserId(Long userId);
 
     List<AlgorithmRecord> findFeed(List<Long> userIds, int offset, int size);
+
+    List<String> findActivityDatesByStudyId(Long studyId);
 }

--- a/backend/src/main/java/com/ssafy/dash/algorithm/infrastructure/mapper/AlgorithmRecordMapper.java
+++ b/backend/src/main/java/com/ssafy/dash/algorithm/infrastructure/mapper/AlgorithmRecordMapper.java
@@ -11,46 +11,51 @@ import com.ssafy.dash.algorithm.domain.StudyStats;
 @Mapper
 public interface AlgorithmRecordMapper {
 
-    void insert(AlgorithmRecord record);
+        void insert(AlgorithmRecord record);
 
-    AlgorithmRecord selectById(Long id);
+        AlgorithmRecord selectById(Long id);
 
-    List<AlgorithmRecord> selectAll();
+        List<AlgorithmRecord> selectAll();
 
-    List<AlgorithmRecord> selectByUserId(Long userId);
+        List<AlgorithmRecord> selectByUserId(Long userId);
 
-    List<AlgorithmRecord> selectByStudyId(Long studyId);
+        List<AlgorithmRecord> selectByStudyId(Long studyId);
 
-    void save(AlgorithmRecord record);
+        void save(AlgorithmRecord record);
 
-    void update(AlgorithmRecord record);
+        void update(AlgorithmRecord record);
 
-    StudyStats countsByStudyId(Long studyId);
+        StudyStats countsByStudyId(Long studyId);
 
-    int delete(Long id);
+        int delete(Long id);
 
-    int countSuccessfulSubmissionByUserIdAndProblemNumber(Long userId, String problemNumber);
+        int countSuccessfulSubmissionByUserIdAndProblemNumber(Long userId, String problemNumber);
 
-    List<String> selectSolvedProblemNumbersByUserId(Long userId);
+        List<String> selectSolvedProblemNumbersByUserId(Long userId);
 
-    AlgorithmRecord selectLatestSuccessfulByUserAndProblem(Long userId, String problemNumber);
+        AlgorithmRecord selectLatestSuccessfulByUserAndProblem(Long userId, String problemNumber);
 
-    void migrateStudyId(Long oldStudyId, Long newStudyId);
+        void migrateStudyId(Long oldStudyId, Long newStudyId);
 
-    void migrateUserRecords(Long userId, Long oldStudyId, Long newStudyId);
+        void migrateUserRecords(Long userId, Long oldStudyId, Long newStudyId);
 
-    List<com.ssafy.dash.dashboard.application.dto.response.HeatmapRawData> selectHeatmapDataByStudyId(Long studyId);
+        List<com.ssafy.dash.dashboard.application.dto.response.HeatmapRawData> selectHeatmapDataByStudyId(Long studyId);
 
-    List<com.ssafy.dash.dashboard.application.dto.response.HeatmapRawData> selectHeatmapDataByUserId(Long userId);
+        List<com.ssafy.dash.dashboard.application.dto.response.HeatmapRawData> selectHeatmapDataByUserId(Long userId);
 
-    List<AlgorithmRecord> selectFriendFeed(@Param("userIds") List<Long> userIds, @Param("offset") int offset,
-            @Param("size") int size);
+        List<AlgorithmRecord> selectFriendFeed(@Param("userIds") List<Long> userIds, @Param("offset") int offset,
+                        @Param("size") int size);
 
-    /**
-     * Solved.ac에서 동기화한 푼 문제 삽입 (중복 무시)
-     */
-    void insertSolvedProblemIfNotExists(@org.apache.ibatis.annotations.Param("userId") Long userId,
-            @org.apache.ibatis.annotations.Param("problemNumber") String problemNumber,
-            @org.apache.ibatis.annotations.Param("title") String title,
-            @org.apache.ibatis.annotations.Param("level") int level);
+        /**
+         * Solved.ac에서 동기화한 푼 문제 삽입 (중복 무시)
+         */
+        void insertSolvedProblemIfNotExists(@org.apache.ibatis.annotations.Param("userId") Long userId,
+                        @org.apache.ibatis.annotations.Param("problemNumber") String problemNumber,
+                        @org.apache.ibatis.annotations.Param("title") String title,
+                        @org.apache.ibatis.annotations.Param("level") int level);
+
+        /**
+         * 스터디의 활동 날짜 목록 조회 (streak 계산용) - 최근 60일
+         */
+        List<String> selectActivityDatesByStudyId(Long studyId);
 }

--- a/backend/src/main/java/com/ssafy/dash/algorithm/infrastructure/persistence/AlgorithmRecordRepositoryImpl.java
+++ b/backend/src/main/java/com/ssafy/dash/algorithm/infrastructure/persistence/AlgorithmRecordRepositoryImpl.java
@@ -101,4 +101,9 @@ public class AlgorithmRecordRepositoryImpl implements AlgorithmRecordRepository 
     public List<AlgorithmRecord> findFeed(List<Long> userIds, int offset, int size) {
         return mapper.selectFriendFeed(userIds, offset, size);
     }
+
+    @Override
+    public List<String> findActivityDatesByStudyId(Long studyId) {
+        return mapper.selectActivityDatesByStudyId(studyId);
+    }
 }

--- a/backend/src/main/java/com/ssafy/dash/study/application/StreakInitializer.java
+++ b/backend/src/main/java/com/ssafy/dash/study/application/StreakInitializer.java
@@ -1,0 +1,103 @@
+package com.ssafy.dash.study.application;
+
+import com.ssafy.dash.study.domain.Study;
+import com.ssafy.dash.study.domain.StudyRepository;
+import com.ssafy.dash.algorithm.domain.AlgorithmRecordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 서버 시작 시 기존 스터디의 streak 초기화 (1회성)
+ * streak과 streakUpdatedAt이 NULL인 스터디만 처리
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StreakInitializer {
+
+    private final StudyRepository studyRepository;
+    private final AlgorithmRecordRepository algorithmRecordRepository;
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void initializeStreaks() {
+        log.info("Streak 초기화 시작...");
+
+        List<Study> studies = studyRepository.findAll();
+        int initialized = 0;
+
+        for (Study study : studies) {
+            // 이미 초기화된 스터디는 스킵
+            if (study.getStreakUpdatedAt() != null) {
+                continue;
+            }
+
+            // 활동 날짜 조회 및 streak 계산
+            int streak = calculateStreakFromHistory(study.getId());
+
+            // 오늘 또는 어제 활동이 있으면 해당 날짜로 설정
+            LocalDate updatedAt = determineLastActivityDate(study.getId());
+
+            if (updatedAt != null) {
+                study.setStreak(streak);
+                study.setStreakUpdatedAt(updatedAt);
+                studyRepository.update(study);
+                initialized++;
+                log.debug("Study {} 초기화: streak={}, updatedAt={}", study.getId(), streak, updatedAt);
+            }
+        }
+
+        log.info("Streak 초기화 완료: {}개 스터디 처리", initialized);
+    }
+
+    private int calculateStreakFromHistory(Long studyId) {
+        List<String> activityDates = algorithmRecordRepository.findActivityDatesByStudyId(studyId);
+        if (activityDates == null || activityDates.isEmpty()) {
+            return 0;
+        }
+
+        LocalDate today = LocalDate.now();
+        Set<LocalDate> activitySet = activityDates.stream()
+                .map(LocalDate::parse)
+                .collect(Collectors.toSet());
+
+        int streak = 0;
+        LocalDate checkDate = today;
+
+        // 오늘부터 시작해서 연속으로 활동이 있는 날을 카운트
+        while (activitySet.contains(checkDate)) {
+            streak++;
+            checkDate = checkDate.minusDays(1);
+        }
+
+        // 오늘 활동이 없으면 어제부터 체크
+        if (streak == 0) {
+            checkDate = today.minusDays(1);
+            while (activitySet.contains(checkDate)) {
+                streak++;
+                checkDate = checkDate.minusDays(1);
+            }
+        }
+
+        return streak;
+    }
+
+    private LocalDate determineLastActivityDate(Long studyId) {
+        List<String> activityDates = algorithmRecordRepository.findActivityDatesByStudyId(studyId);
+        if (activityDates == null || activityDates.isEmpty()) {
+            return null;
+        }
+
+        // 가장 최근 활동 날짜 반환 (이미 DESC 정렬되어 있음)
+        return LocalDate.parse(activityDates.get(0));
+    }
+}

--- a/backend/src/main/java/com/ssafy/dash/study/domain/Study.java
+++ b/backend/src/main/java/com/ssafy/dash/study/domain/Study.java
@@ -1,5 +1,6 @@
 package com.ssafy.dash.study.domain;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import lombok.Getter;
@@ -34,6 +35,7 @@ public class Study {
     private Double averageSubmissionRate; // 기록 제출률
     // averageTier는 기존 필드 사용
     private Integer streak; // 연속 활동 일수
+    private LocalDate streakUpdatedAt; // streak 마지막 갱신일 (캐싱용)
     private String activeMissionTitle; // 진행 중인 미션
     private Integer activeMissionProgress; // 미션 진행률
 

--- a/backend/src/main/java/com/ssafy/dash/study/presentation/dto/response/StudyListResponse.java
+++ b/backend/src/main/java/com/ssafy/dash/study/presentation/dto/response/StudyListResponse.java
@@ -3,6 +3,7 @@ package com.ssafy.dash.study.presentation.dto.response;
 import com.ssafy.dash.study.domain.Study;
 import com.ssafy.dash.user.domain.User;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -18,6 +19,7 @@ public record StudyListResponse(
         Integer acornCount,
         String mvpUsername,
         Integer streak,
+        LocalDate streakUpdatedAt, // streak 유효성 판단용
         Double averageSubmissionRate,
         List<MemberPreview> memberPreviews, // 멤버 미리보기 (프론트에서 표시 개수 조절)
         String description) {
@@ -39,6 +41,7 @@ public record StudyListResponse(
                 study.getAcornCount() != null ? study.getAcornCount() : 0,
                 study.getMvpUsername(),
                 study.getStreak() != null ? study.getStreak() : 0,
+                study.getStreakUpdatedAt(),
                 study.getAverageSubmissionRate() != null ? study.getAverageSubmissionRate() : 0.0,
                 previews,
                 study.getDescription());

--- a/backend/src/main/resources/db/migration/V11__fix_battle_foreign_keys_to_users.sql
+++ b/backend/src/main/resources/db/migration/V11__fix_battle_foreign_keys_to_users.sql
@@ -1,0 +1,9 @@
+-- Fix foreign key references from 'user' to 'users' table
+
+-- Drop existing foreign keys
+ALTER TABLE battle DROP FOREIGN KEY battle_ibfk_1;
+ALTER TABLE battle_participant DROP FOREIGN KEY battle_participant_ibfk_2;
+
+-- Re-create foreign keys with correct table name 'users'
+ALTER TABLE battle ADD CONSTRAINT fk_battle_creator FOREIGN KEY (creator_id) REFERENCES users(id);
+ALTER TABLE battle_participant ADD CONSTRAINT fk_battle_participant_user FOREIGN KEY (user_id) REFERENCES users(id);

--- a/backend/src/main/resources/db/migration/V12__add_streak_updated_at.sql
+++ b/backend/src/main/resources/db/migration/V12__add_streak_updated_at.sql
@@ -1,0 +1,2 @@
+-- Add streak_updated_at column to studies table for O(1) streak calculation
+ALTER TABLE studies ADD COLUMN streak_updated_at DATE;

--- a/backend/src/main/resources/mapper/algorithm/AlgorithmRecordMapper.xml
+++ b/backend/src/main/resources/mapper/algorithm/AlgorithmRecordMapper.xml
@@ -1,185 +1,121 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.ssafy.dash.algorithm.infrastructure.mapper.AlgorithmRecordMapper">
 
   <insert id="insert" parameterType="AlgorithmRecord" useGeneratedKeys="true" keyProperty="id">
-    INSERT INTO algorithm_records (
-      user_id, study_id, problem_number, title, code, language, platform, difficulty,
-      runtime_ms, memory_kb, repository_name, file_path, commit_sha, commit_message,
-      committed_at, created_at, updated_at, record_type, tag, defense_streak, elapsed_time_seconds
-    ) VALUES (
-      #{userId}, #{studyId}, #{problemNumber}, #{title}, #{code}, #{language}, #{platform}, #{difficulty},
-      #{runtimeMs}, #{memoryKb}, #{repositoryName}, #{filePath}, #{commitSha}, #{commitMessage},
-      #{committedAt}, #{createdAt}, #{updatedAt}, #{recordType}, #{tag}, #{defenseStreak}, #{elapsedTimeSeconds}
-    )
-  </insert>
+    INSERT INTO algorithm_records ( user_id, study_id, problem_number, title, code, language,
+    platform, difficulty, runtime_ms, memory_kb, repository_name, file_path, commit_sha,
+    commit_message, committed_at, created_at, updated_at, record_type, tag, defense_streak,
+    elapsed_time_seconds ) VALUES ( #{userId}, #{studyId}, #{problemNumber}, #{title}, #{code},
+    #{language}, #{platform}, #{difficulty}, #{runtimeMs}, #{memoryKb}, #{repositoryName},
+    #{filePath}, #{commitSha}, #{commitMessage}, #{committedAt}, #{createdAt}, #{updatedAt},
+    #{recordType}, #{tag}, #{defenseStreak}, #{elapsedTimeSeconds} ) </insert>
 
-  <select id="selectById" resultType="AlgorithmRecord" parameterType="long">
-    SELECT r.*, u.username,
-           car.score, car.time_complexity, car.space_complexity, car.complexity_explanation, 
-           car.patterns, car.algorithm_intuition, car.pitfalls, car.key_blocks, 
-           car.refactor_provided, car.refactor_code, car.refactor_explanation, car.full_response,
-           car.counter_example_input, car.counter_example_expected, car.counter_example_predicted, car.counter_example_reason
-    FROM algorithm_records r
-    LEFT JOIN users u ON r.user_id = u.id
-    LEFT JOIN code_analysis_results car ON r.id = car.algorithm_record_id
-    WHERE r.id = #{id}
-  </select>
+  <select id="selectById" resultType="AlgorithmRecord" parameterType="long"> SELECT r.*, u.username,
+    car.score, car.time_complexity, car.space_complexity, car.complexity_explanation, car.patterns,
+    car.algorithm_intuition, car.pitfalls, car.key_blocks, car.refactor_provided, car.refactor_code,
+    car.refactor_explanation, car.full_response, car.counter_example_input,
+    car.counter_example_expected, car.counter_example_predicted, car.counter_example_reason FROM
+    algorithm_records r LEFT JOIN users u ON r.user_id = u.id LEFT JOIN code_analysis_results car ON
+    r.id = car.algorithm_record_id WHERE r.id = #{id} </select>
 
-  <select id="selectAll" resultType="AlgorithmRecord">
-    SELECT r.*, r.tag, u.username,
-           car.score, car.time_complexity, car.space_complexity, car.complexity_explanation, 
-           car.patterns, car.algorithm_intuition, car.pitfalls, car.key_blocks, 
-           car.refactor_provided, car.refactor_code, car.refactor_explanation, car.full_response,
-           car.counter_example_input, car.counter_example_expected, car.counter_example_predicted, car.counter_example_reason
-    FROM algorithm_records r
-    LEFT JOIN users u ON r.user_id = u.id
-    LEFT JOIN code_analysis_results car ON r.id = car.algorithm_record_id
-    ORDER BY r.id DESC
-  </select>
+  <select id="selectAll" resultType="AlgorithmRecord"> SELECT r.*, r.tag, u.username, car.score,
+    car.time_complexity, car.space_complexity, car.complexity_explanation, car.patterns,
+    car.algorithm_intuition, car.pitfalls, car.key_blocks, car.refactor_provided, car.refactor_code,
+    car.refactor_explanation, car.full_response, car.counter_example_input,
+    car.counter_example_expected, car.counter_example_predicted, car.counter_example_reason FROM
+    algorithm_records r LEFT JOIN users u ON r.user_id = u.id LEFT JOIN code_analysis_results car ON
+    r.id = car.algorithm_record_id ORDER BY r.id DESC </select>
 
-  <select id="selectByUserId" resultType="AlgorithmRecord" parameterType="long">
-    SELECT r.*, u.username,
-           car.score, car.time_complexity, car.space_complexity, car.complexity_explanation, 
-           car.patterns, car.algorithm_intuition, car.pitfalls, car.key_blocks, 
-           car.refactor_provided, car.refactor_code, car.refactor_explanation, car.full_response,
-           car.counter_example_input, car.counter_example_expected, car.counter_example_predicted, car.counter_example_reason
-    FROM algorithm_records r
-    LEFT JOIN users u ON r.user_id = u.id
-    LEFT JOIN code_analysis_results car ON r.id = car.algorithm_record_id
-    WHERE r.user_id = #{userId} AND r.record_type = 'USER_SOLUTION'
-    ORDER BY r.id DESC
-  </select>
+  <select id="selectByUserId" resultType="AlgorithmRecord" parameterType="long"> SELECT r.*,
+    u.username, car.score, car.time_complexity, car.space_complexity, car.complexity_explanation,
+    car.patterns, car.algorithm_intuition, car.pitfalls, car.key_blocks, car.refactor_provided,
+    car.refactor_code, car.refactor_explanation, car.full_response, car.counter_example_input,
+    car.counter_example_expected, car.counter_example_predicted, car.counter_example_reason FROM
+    algorithm_records r LEFT JOIN users u ON r.user_id = u.id LEFT JOIN code_analysis_results car ON
+    r.id = car.algorithm_record_id WHERE r.user_id = #{userId} AND r.record_type = 'USER_SOLUTION'
+    ORDER BY r.id DESC </select>
 
-  <select id="selectByStudyId" resultType="AlgorithmRecord" parameterType="long">
-    SELECT r.*, u.username,
-           car.score, car.time_complexity, car.space_complexity, car.complexity_explanation, 
-           car.patterns, car.algorithm_intuition, car.pitfalls, car.key_blocks, 
-           car.refactor_provided, car.refactor_code, car.refactor_explanation, car.full_response,
-           car.counter_example_input, car.counter_example_expected, car.counter_example_predicted, car.counter_example_reason
-    FROM algorithm_records r
-    LEFT JOIN users u ON r.user_id = u.id
-    LEFT JOIN code_analysis_results car ON r.id = car.algorithm_record_id
-    WHERE r.study_id = #{studyId} AND r.record_type = 'USER_SOLUTION' 
-    ORDER BY r.id DESC
-  </select>
+  <select id="selectByStudyId" resultType="AlgorithmRecord" parameterType="long"> SELECT r.*,
+    u.username, car.score, car.time_complexity, car.space_complexity, car.complexity_explanation,
+    car.patterns, car.algorithm_intuition, car.pitfalls, car.key_blocks, car.refactor_provided,
+    car.refactor_code, car.refactor_explanation, car.full_response, car.counter_example_input,
+    car.counter_example_expected, car.counter_example_predicted, car.counter_example_reason FROM
+    algorithm_records r LEFT JOIN users u ON r.user_id = u.id LEFT JOIN code_analysis_results car ON
+    r.id = car.algorithm_record_id WHERE r.study_id = #{studyId} AND r.record_type = 'USER_SOLUTION'
+    ORDER BY r.id DESC </select>
 
-  <select id="selectFriendFeed" resultType="AlgorithmRecord">
-    SELECT r.*, u.username, u.avatar_url, u.solvedac_tier,
-           car.score, car.time_complexity, car.space_complexity, car.complexity_explanation,
-           car.patterns, car.algorithm_intuition, car.pitfalls, car.key_blocks,
-           car.refactor_provided, car.refactor_code, car.refactor_explanation, car.full_response,
-           car.counter_example_input, car.counter_example_expected, car.counter_example_predicted, car.counter_example_reason
-    FROM algorithm_records r
-    JOIN users u ON r.user_id = u.id
-    LEFT JOIN code_analysis_results car ON r.id = car.algorithm_record_id
-    WHERE r.user_id IN
-    <foreach item="userId" collection="userIds" open="(" separator="," close=")">
-      #{userId}
-    </foreach>
-    AND r.record_type = 'USER_SOLUTION'
-    ORDER BY r.created_at DESC
-    LIMIT #{size} OFFSET #{offset}
-  </select>
+  <select id="selectFriendFeed" resultType="AlgorithmRecord"> SELECT r.*, u.username, u.avatar_url,
+    u.solvedac_tier, car.score, car.time_complexity, car.space_complexity,
+    car.complexity_explanation, car.patterns, car.algorithm_intuition, car.pitfalls, car.key_blocks,
+    car.refactor_provided, car.refactor_code, car.refactor_explanation, car.full_response,
+    car.counter_example_input, car.counter_example_expected, car.counter_example_predicted,
+    car.counter_example_reason FROM algorithm_records r JOIN users u ON r.user_id = u.id LEFT JOIN
+    code_analysis_results car ON r.id = car.algorithm_record_id WHERE r.user_id IN <foreach
+      item="userId" collection="userIds" open="(" separator="," close=")"> #{userId} </foreach> AND
+    r.record_type = 'USER_SOLUTION' ORDER BY r.created_at DESC LIMIT #{size} OFFSET #{offset} </select>
 
-  <update id="update" parameterType="AlgorithmRecord">
-    UPDATE algorithm_records
-    SET problem_number = #{problemNumber}, title = #{title}, code = #{code}, language = #{language},
-        platform = #{platform}, difficulty = #{difficulty}, runtime_ms = #{runtimeMs}, memory_kb = #{memoryKb},
-        repository_name = #{repositoryName}, file_path = #{filePath}, commit_sha = #{commitSha},
-        commit_message = #{commitMessage}, committed_at = #{committedAt}, updated_at = #{updatedAt},
-        defense_streak = #{defenseStreak}, tag = #{tag}, elapsed_time_seconds = #{elapsedTimeSeconds}
-    WHERE id = #{id}
-  </update>
+  <update id="update" parameterType="AlgorithmRecord"> UPDATE algorithm_records SET problem_number =
+    #{problemNumber}, title = #{title}, code = #{code}, language = #{language}, platform =
+    #{platform}, difficulty = #{difficulty}, runtime_ms = #{runtimeMs}, memory_kb = #{memoryKb},
+    repository_name = #{repositoryName}, file_path = #{filePath}, commit_sha = #{commitSha},
+    commit_message = #{commitMessage}, committed_at = #{committedAt}, updated_at = #{updatedAt},
+    defense_streak = #{defenseStreak}, tag = #{tag}, elapsed_time_seconds = #{elapsedTimeSeconds}
+    WHERE id = #{id} </update>
 
-  <delete id="delete" parameterType="long">
-    DELETE FROM algorithm_records WHERE id = #{id}
-  </delete>
+  <delete id="delete" parameterType="long"> DELETE FROM algorithm_records WHERE id = #{id} </delete>
 
-  <select id="countsByStudyId" resultType="com.ssafy.dash.algorithm.domain.StudyStats" parameterType="long">
-    SELECT
-      COALESCE(SUM(CASE WHEN r.difficulty LIKE '%Bronze%' OR (r.difficulty REGEXP '^[1-5]$') THEN 1 ELSE 0 END), 0) as bronze,
-      COALESCE(SUM(CASE WHEN r.difficulty LIKE '%Silver%' OR (r.difficulty REGEXP '^([6-9]|10)$') THEN 1 ELSE 0 END), 0) as silver,
-      COALESCE(SUM(CASE WHEN r.difficulty LIKE '%Gold%' OR (r.difficulty REGEXP '^(1[1-5])$') THEN 1 ELSE 0 END), 0) as gold,
-      COALESCE(SUM(CASE WHEN r.difficulty LIKE '%Platinum%' OR (r.difficulty REGEXP '^(1[6-9]|20)$') THEN 1 ELSE 0 END), 0) as platinum
-    FROM algorithm_records r
-    INNER JOIN users u ON r.user_id = u.id
-    WHERE u.study_id = #{studyId} AND u.deleted_at IS NULL AND r.record_type = 'USER_SOLUTION'
-  </select>
+  <select id="countsByStudyId" resultType="com.ssafy.dash.algorithm.domain.StudyStats"
+    parameterType="long"> SELECT COALESCE(SUM(CASE WHEN r.difficulty LIKE '%Bronze%' OR
+    (r.difficulty REGEXP '^[1-5]$') THEN 1 ELSE 0 END), 0) as bronze, COALESCE(SUM(CASE WHEN
+    r.difficulty LIKE '%Silver%' OR (r.difficulty REGEXP '^([6-9]|10)$') THEN 1 ELSE 0 END), 0) as
+    silver, COALESCE(SUM(CASE WHEN r.difficulty LIKE '%Gold%' OR (r.difficulty REGEXP '^(1[1-5])$')
+    THEN 1 ELSE 0 END), 0) as gold, COALESCE(SUM(CASE WHEN r.difficulty LIKE '%Platinum%' OR
+    (r.difficulty REGEXP '^(1[6-9]|20)$') THEN 1 ELSE 0 END), 0) as platinum FROM algorithm_records
+    r INNER JOIN users u ON r.user_id = u.id WHERE u.study_id = #{studyId} AND u.deleted_at IS NULL
+    AND r.record_type = 'USER_SOLUTION' </select>
 
-  <select id="countSuccessfulSubmissionByUserIdAndProblemNumber" resultType="int">
-    SELECT COUNT(*)
-    FROM algorithm_records
-    WHERE user_id = #{userId} AND record_type = 'USER_SOLUTION'
-      AND problem_number = #{problemNumber}
-      AND runtime_ms IS NOT NULL
-      AND memory_kb IS NOT NULL
-  </select>
+  <select id="countSuccessfulSubmissionByUserIdAndProblemNumber" resultType="int"> SELECT COUNT(*)
+    FROM algorithm_records WHERE user_id = #{userId} AND record_type = 'USER_SOLUTION' AND
+    problem_number = #{problemNumber} AND runtime_ms IS NOT NULL AND memory_kb IS NOT NULL </select>
 
-  <select id="selectSolvedProblemNumbersByUserId" resultType="string" parameterType="long">
-    SELECT DISTINCT problem_number
-    FROM algorithm_records
-    WHERE user_id = #{userId}
-      AND (record_type = 'SOLVED_AC_SYNC' 
-           OR (runtime_ms IS NOT NULL AND memory_kb IS NOT NULL))
-  </select>
+  <select id="selectSolvedProblemNumbersByUserId" resultType="string" parameterType="long"> SELECT
+    DISTINCT problem_number FROM algorithm_records WHERE user_id = #{userId} AND (record_type =
+    'SOLVED_AC_SYNC' OR (runtime_ms IS NOT NULL AND memory_kb IS NOT NULL)) </select>
 
-  <select id="selectLatestSuccessfulByUserAndProblem" resultType="AlgorithmRecord">
-    SELECT *
-    FROM algorithm_records
-    WHERE user_id = #{userId}
-      AND problem_number = #{problemNumber}
-      AND runtime_ms IS NOT NULL
-      AND memory_kb IS NOT NULL
-    ORDER BY created_at DESC
-    LIMIT 1
-  </select>
+  <select id="selectLatestSuccessfulByUserAndProblem" resultType="AlgorithmRecord"> SELECT * FROM
+    algorithm_records WHERE user_id = #{userId} AND problem_number = #{problemNumber} AND runtime_ms
+    IS NOT NULL AND memory_kb IS NOT NULL ORDER BY created_at DESC LIMIT 1 </select>
 
-  <update id="migrateStudyId">
-    UPDATE algorithm_records
-    SET study_id = #{newStudyId}
-    WHERE study_id = #{oldStudyId}
-  </update>
+  <update id="migrateStudyId"> UPDATE algorithm_records SET study_id = #{newStudyId} WHERE study_id
+    = #{oldStudyId} </update>
 
-  <update id="migrateUserRecords">
-    UPDATE algorithm_records
-    SET study_id = #{newStudyId}
-    WHERE user_id = #{userId}
-  </update>
+  <update id="migrateUserRecords"> UPDATE algorithm_records SET study_id = #{newStudyId} WHERE
+    user_id = #{userId} </update>
 
-  <select id="selectHeatmapDataByStudyId" resultType="com.ssafy.dash.dashboard.application.dto.response.HeatmapRawData">
-    SELECT
-      DATE_FORMAT(r.committed_at, '%Y-%m-%d') as date,
-      u.id as userId,
-      u.username,
-      u.avatar_url as avatarUrl,
-      COUNT(*) as dailyCount
-    FROM algorithm_records r
-    JOIN users u ON r.user_id = u.id
-    WHERE r.study_id = #{studyId} AND r.record_type = 'USER_SOLUTION'
-    GROUP BY DATE_FORMAT(r.committed_at, '%Y-%m-%d'), u.id
-    ORDER BY date ASC
-  </select>
+  <select id="selectHeatmapDataByStudyId"
+    resultType="com.ssafy.dash.dashboard.application.dto.response.HeatmapRawData"> SELECT
+    DATE_FORMAT(r.committed_at, '%Y-%m-%d') as date, u.id as userId, u.username, u.avatar_url as
+    avatarUrl, COUNT(*) as dailyCount FROM algorithm_records r JOIN users u ON r.user_id = u.id
+    WHERE r.study_id = #{studyId} AND r.record_type = 'USER_SOLUTION' GROUP BY
+    DATE_FORMAT(r.committed_at, '%Y-%m-%d'), u.id ORDER BY date ASC </select>
 
-  <select id="selectHeatmapDataByUserId" resultType="com.ssafy.dash.dashboard.application.dto.response.HeatmapRawData">
-    SELECT
-      DATE_FORMAT(r.committed_at, '%Y-%m-%d') as date,
-      u.id as userId,
-      u.username,
-      u.avatar_url as avatarUrl,
-      COUNT(*) as dailyCount
-    FROM algorithm_records r
-    JOIN users u ON r.user_id = u.id
-    WHERE r.user_id = #{userId} AND r.record_type = 'USER_SOLUTION'
-    GROUP BY DATE_FORMAT(r.committed_at, '%Y-%m-%d'), u.id
-    ORDER BY date ASC
-  </select>
+  <select id="selectHeatmapDataByUserId"
+    resultType="com.ssafy.dash.dashboard.application.dto.response.HeatmapRawData"> SELECT
+    DATE_FORMAT(r.committed_at, '%Y-%m-%d') as date, u.id as userId, u.username, u.avatar_url as
+    avatarUrl, COUNT(*) as dailyCount FROM algorithm_records r JOIN users u ON r.user_id = u.id
+    WHERE r.user_id = #{userId} AND r.record_type = 'USER_SOLUTION' GROUP BY
+    DATE_FORMAT(r.committed_at, '%Y-%m-%d'), u.id ORDER BY date ASC </select>
 
-  <insert id="insertSolvedProblemIfNotExists">
-    INSERT IGNORE INTO algorithm_records 
-      (user_id, problem_number, title, difficulty, record_type, created_at, updated_at)
-    VALUES 
-      (#{userId}, #{problemNumber}, #{title}, #{level}, 'SOLVED_AC_SYNC', NOW(), NOW())
-  </insert>
+  <insert id="insertSolvedProblemIfNotExists"> INSERT IGNORE INTO algorithm_records (user_id,
+    problem_number, title, difficulty, record_type, created_at, updated_at) VALUES (#{userId},
+    #{problemNumber}, #{title}, #{level}, 'SOLVED_AC_SYNC', NOW(), NOW()) </insert>
+
+  <!-- 스터디의 활동 날짜 목록 조회 (streak 계산용) -->
+  <select id="selectActivityDatesByStudyId" resultType="string" parameterType="long"> SELECT
+    DISTINCT DATE_FORMAT(r.committed_at, '%Y-%m-%d') as activity_date FROM algorithm_records r JOIN
+    users u ON r.user_id = u.id WHERE u.study_id = #{studyId} AND u.deleted_at IS NULL AND
+    r.record_type = 'USER_SOLUTION' AND r.committed_at >= DATE_SUB(CURDATE(), INTERVAL 60 DAY) ORDER
+    BY activity_date DESC </select>
 
 </mapper>

--- a/backend/src/main/resources/mapper/study/StudyMapper.xml
+++ b/backend/src/main/resources/mapper/study/StudyMapper.xml
@@ -4,9 +4,9 @@
 
   <insert id="save" parameterType="Study" useGeneratedKeys="true" keyProperty="id"> INSERT INTO
     studies (name, creator_id, created_at, acorn_count, visibility, description, streak,
-    active_mission_title, active_mission_progress, study_type) VALUES (#{name}, #{creatorId},
-    #{createdAt}, #{acornCount}, #{visibility}, #{description}, #{streak}, #{activeMissionTitle},
-    #{activeMissionProgress}, #{studyType}) </insert>
+    streak_updated_at, active_mission_title, active_mission_progress, study_type) VALUES (#{name},
+    #{creatorId}, #{createdAt}, #{acornCount}, #{visibility}, #{description}, #{streak},
+    #{streakUpdatedAt}, #{activeMissionTitle}, #{activeMissionProgress}, #{studyType}) </insert>
 
   <select id="findById" resultType="Study" parameterType="long"> SELECT s.*, (SELECT COUNT(*) FROM
     users u WHERE u.study_id = s.id AND u.deleted_at IS NULL) as member_count, (SELECT
@@ -50,8 +50,9 @@
 
   <update id="update" parameterType="Study"> UPDATE studies SET name = #{name}, acorn_count =
     #{acornCount}, visibility = #{visibility}, description = #{description}, streak = #{streak},
-    active_mission_title = #{activeMissionTitle}, active_mission_progress =
-    #{activeMissionProgress}, study_type = #{studyType}, creator_id = #{creatorId} WHERE id = #{id} </update>
+    streak_updated_at = #{streakUpdatedAt}, active_mission_title = #{activeMissionTitle},
+    active_mission_progress = #{activeMissionProgress}, study_type = #{studyType}, creator_id =
+    #{creatorId} WHERE id = #{id} </update>
 
   <delete id="delete" parameterType="long"> DELETE FROM studies WHERE id = #{id} </delete>
 
@@ -61,8 +62,8 @@
     message, status, created_at) VALUES (#{studyId}, #{userId}, #{message}, #{status}, #{createdAt}) </insert>
 
   <select id="findApplicationById" resultMap="StudyApplicationResult"> SELECT sa.*, u.id as u_id,
-    u.username, u.avatar_url, u.deleted_at as u_deleted_at FROM study_applications sa JOIN users u ON sa.user_id = u.id WHERE
-    sa.id = #{id} </select>
+    u.username, u.avatar_url, u.deleted_at as u_deleted_at FROM study_applications sa JOIN users u
+    ON sa.user_id = u.id WHERE sa.id = #{id} </select>
 
   <select id="findApplicationByStudyIdAndUserId"
     resultType="com.ssafy.dash.study.domain.StudyApplication"> SELECT * FROM study_applications
@@ -89,8 +90,8 @@
   </resultMap>
 
   <select id="findPendingApplicationsByStudyId" resultMap="StudyApplicationResult"> SELECT sa.*,
-    u.id as u_id, u.username, u.avatar_url, u.deleted_at as u_deleted_at FROM study_applications sa JOIN users u ON sa.user_id =
-    u.id WHERE sa.study_id = #{studyId} AND sa.status = 'PENDING' </select>
+    u.id as u_id, u.username, u.avatar_url, u.deleted_at as u_deleted_at FROM study_applications sa
+    JOIN users u ON sa.user_id = u.id WHERE sa.study_id = #{studyId} AND sa.status = 'PENDING' </select>
 
   <select id="findPendingApplicationByUserId" resultMap="StudyApplicationResult"> SELECT * FROM
     study_applications WHERE user_id = #{userId} AND status = 'PENDING' </select>

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -335,6 +335,7 @@ import {
 } from "lucide-vue-next";
 
 import { useAuth } from "@/composables/useAuth";
+import { useFloatingChat } from "@/composables/useFloatingChat";
 import { authApi } from "@/api/auth";
 import { getNotifications, markAsRead, markAllAsRead, updateNotification } from "@/api/notification";
 import { studyApi } from "@/api/study";
@@ -342,6 +343,7 @@ import { studyApi } from "@/api/study";
 const emits = defineEmits(['scroll']);
 
 const { user, logout, refresh } = useAuth();
+const { triggerRefresh: refreshChatList } = useFloatingChat();
 const route = useRoute();
 const router = useRouter();
 
@@ -472,6 +474,10 @@ const fetchNotifications = async () => {
                 });
             }
         });
+        // DM 알림이 있으면 채팅 목록도 즉시 새로고침
+        if (newNotifications.some(n => n.type === 'DIRECT_MESSAGE')) {
+            refreshChatList();
+        }
     }
 
     notifications.value = data;

--- a/frontend/src/composables/useFloatingChat.js
+++ b/frontend/src/composables/useFloatingChat.js
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 // Global state for FloatingMessagePanel
 const isOpen = ref(false);
 const activeChat = ref(null); // { partnerId, partnerName, partnerAvatar, partnerDecoration }
+const refreshTrigger = ref(0); // 채팅 목록 새로고침 트리거
 
 export function useFloatingChat() {
 
@@ -24,11 +25,18 @@ export function useFloatingChat() {
         isOpen.value = !isOpen.value;
     };
 
+    // DM 알림 수신 시 채팅 목록 새로고침 트리거
+    const triggerRefresh = () => {
+        refreshTrigger.value++;
+    };
+
     return {
         isOpen,
         activeChat,
+        refreshTrigger,
         openChat,
         closeChat,
-        toggle
+        toggle,
+        triggerRefresh
     };
 }

--- a/frontend/src/views/dashboard/DashboardView.vue
+++ b/frontend/src/views/dashboard/DashboardView.vue
@@ -799,27 +799,26 @@ watch(() => studyData.value, () => {
 });
 
 
-// Computed: 현재 스트릭 (연속 활동 일수)
+// Computed: 현재 스트릭 (백엔드 캐시 데이터 사용)
 const currentStreak = computed(() => {
-    if (!heatmapWeeks.value.length) return 0;
+    if (!studyData.value) return 0;
     
-    // 주간 데이터를 날짜 배열로 평탄화하고 오늘부터 시작하도록 역순 정렬
-    const allDays = heatmapWeeks.value.flat().reverse();
+    // 백엔드에서 streakUpdatedAt과 streak 값을 받아옴
+    const streak = studyData.value.streak || 0;
+    const updatedAt = studyData.value.streakUpdatedAt;
     
-    let streak = 0;
-    const today = new Date().toISOString().split('T')[0];
+    // streak 유효성 판단: updatedAt이 어제 이전이면 체인 끊김
+    if (!updatedAt) return 0;
     
-    for (const day of allDays) {
-        // 미래 날짜 건너뛰기
-        if (day.date > today) continue;
-        
-        if (day.count > 0) {
-            streak++;
-        } else if (streak > 0 || day.date === today) {
-            // 오늘 활동이 없으면 스트릭 0
-            // 이전에 활동이 있었는데 0을 만나면 카운팅 중단
-            break;
-        }
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setHours(0, 0, 0, 0);
+    
+    const updatedDate = new Date(updatedAt);
+    updatedDate.setHours(0, 0, 0, 0);
+    
+    if (updatedDate < yesterday) {
+        return 0;  // 체인 끊김
     }
     
     return streak;

--- a/frontend/src/views/social/SocialView.vue
+++ b/frontend/src/views/social/SocialView.vue
@@ -16,20 +16,7 @@
                                     </div>
                                     <p class="text-slate-500 font-medium">친구들과 함께 공부하고 소통해보세요</p>
                                 </div>
-                                
-                                <div class="flex bg-slate-100 p-1 rounded-xl font-bold">
-                                    <button 
-                                        v-for="tab in tabs" 
-                                        :key="tab.id"
-                                        @click="activeTab = tab.id"
-                                        class="px-5 py-2.5 rounded-lg text-sm transition-all"
-                                        :class="activeTab === tab.id ? 'bg-white text-brand-600 shadow-sm' : 'text-slate-400 hover:text-slate-600'"
-                                    >
-                                        {{ tab.label }}
-                                        <span v-if="tab.count > 0" class="ml-1 px-1.5 py-0.5 bg-rose-500 text-white text-[10px] rounded-full">{{ tab.count }}</span>
-                                    </button>
                                 </div>
-                            </div>
 
                             <!-- 피드 영역 -->
                             <div class="space-y-4">
@@ -133,8 +120,8 @@
                                     <div class="space-y-2">
                                         <div v-for="req in requests" :key="req.id" class="flex items-center justify-between p-2.5 rounded-xl bg-white border border-rose-100 shadow-sm">
                                             <div class="flex items-center gap-2.5 min-w-0">
-                                                <img :src="getAvatar(req.requester?.avatarUrl)" class="w-8 h-8 rounded-full border border-slate-200"/>
-                                                <span class="text-sm font-bold text-slate-700 truncate">{{ req.requester?.username || '알 수 없음' }}</span>
+                                                <img :src="getAvatar(req.friend?.avatarUrl)" class="w-8 h-8 rounded-full border border-slate-200"/>
+                                                <span class="text-sm font-bold text-slate-700 truncate">{{ req.friend?.username || '알 수 없음' }}</span>
                                             </div>
                                             <div class="flex items-center gap-1.5">
                                                 <button @click="acceptRequest(req.id)" class="p-1.5 bg-emerald-500 text-white rounded-lg hover:bg-emerald-600 transition-colors">
@@ -209,15 +196,9 @@ const router = useRouter();
 const { openChat: openGlobalDM } = useFloatingChat();
 const { open: openProfile } = useUserProfileModal();
 
-// 탭 상태
+// 탭 상태 (더 이상 탭이 없으므로 피드만 표시)
 const activeTab = ref('feed');
 const requests = ref([]);
-
-// 탭 정의
-const tabs = computed(() => [
-    { id: 'feed', label: '피드', count: 0 },
-    { id: 'requests', label: '친구 요청', count: requests.value.length }
-]);
 
 // 피드 상태
 const feedItems = ref([]);


### PR DESCRIPTION
## 🚀 작업 배경

스터디 성과 지표의 실시간성 및 성능 개선, 배틀 기능의 사용자 경험 향상, 그리고 프론트엔드 UI/UX 중복 요소 정리를 위한 작업입니다. 특히 스터디 streak 조회 시 매번 계산하던 비효율적인 로직을 O(1) 캐시 기반으로 최적화하고, 배틀 결과 화면의 승패 표시를 개선했습니다.

---

## 🛠️ 주요 변경 사항

### Backend
- **배틀 외래키 수정**: 배틀 테이블의 외래키 참조를 `users` 테이블로 수정 (DB 마이그레이션 V11)
- **스터디 streak O(1) 최적화**: 매 요청 시 계산하던 streak을 서버 시작 시 초기화하고 캐시 기반으로 조회하도록 개선
- **채팅 알림 배지 로직 개선**: 실시간 업데이트 처리 개선

### Frontend
- **배틀 결과 화면 개선**: 승패 분기 및 정렬 로직 개선으로 결과 표시 명확화
- **대시보드 streak 통합**: 대시보드의 streak을 백엔드 캐시 데이터로 통합하여 일관성 확보
- **소셜 페이지 친구 요청 탭 제거**: 사이드바와 중복되는 탭 제거로 UI 정리

---

## 🔗 관련 이슈
- Closes #64
- Closes #65 