### PR TITLE
fix(frontend): 실패한 문제가 성공으로 표시되는 버그 수정

### DIFF
--- a/frontend/src/views/dashboard/DashboardView.vue
+++ b/frontend/src/views/dashboard/DashboardView.vue
@@ -857,7 +857,7 @@ const groupedRecords = computed(() => {
         }
         const group = groups.get(key);
         group.records.push(record);
-        if (record.result !== 'FAIL') {
+        if (record.result === 'SUCCESS' || record.result === 'PASSED' || (record.runtimeMs !== null && record.runtimeMs !== undefined && record.runtimeMs !== -1)) {
             group.hasSuccess = true;
         }
         // 가장 최신 결과


### PR DESCRIPTION
## 🚀 작업 배경
'문제별 그룹 ' 기능 사용 시, 실제로는 실패한 기록만 있는 문제임에도 불구하고 '성공' 상태로 잘못 표시되는 버그가 있었습니다. 
이로 인해 사용자가 자신이 해결하지 못한 문제를 해결한 것으로 오인할 수 있는 문제가 있어 수정을 진행했습니다.

---

## 🛠️ 주요 변경 사항

- [X] 문제 그룹의 성공 여부(group.hasSuccess)를 판단하는 로직을 강화했습니다.

---

## 🔗 관련 이슈

- Closes #80