### PR TITLE
refactor(code): 단순 문자열 매칭 방식에서 단어 경계를 포함한 정규식 매칭 방식으로 개선

### DIFF
--- a/frontend/src/components/editor/CodeViewer.vue
+++ b/frontend/src/components/editor/CodeViewer.vue
@@ -248,8 +248,19 @@ const keyBlocksByLine = computed(() => {
         else if (block.code) {
            const lines = codeLines.value;
            const targetCode = block.code.trim();
+           
+           // Escape special regex characters
+           const escaped = targetCode.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+           
+           // Add word boundaries if valid identifier characters are at edges
+           const startBoundary = /^\w/.test(targetCode) ? '\\b' : '';
+           const endBoundary = /\w$/.test(targetCode) ? '\\b' : '';
+           
+           // Create regex pattern
+           const pattern = new RegExp(`${startBoundary}${escaped}${endBoundary}`);
+
            for(let i=0; i<lines.length; i++) {
-               if(lines[i].includes(targetCode)) {
+               if(pattern.test(lines[i])) {
                    if (!map[i+1]) map[i+1] = [];
                    map[i+1].push({...block, startLine: i+1});
                }


### PR DESCRIPTION
## 🚀 작업 배경

단순 문자열 매칭 방식으로 인한 잘못된 호버링이 발견되었습니다.

---

## 🛠️ 주요 변경 사항

- [x] 정규식 매칭 방식으로 개선했습니다.