### PR TITLE
fix: 탈퇴한 회원 채팅/친구 목록 UI 표준화 및 프로필 이미지 왜곡 수정

### DIFF
--- a/backend/src/main/java/com/ssafy/dash/social/application/SocialService.java
+++ b/backend/src/main/java/com/ssafy/dash/social/application/SocialService.java
@@ -200,7 +200,7 @@ public class SocialService {
         List<Long> partnerIds = directMessageRepository.findRecentChatPartners(userId);
 
         return partnerIds.stream().map(partnerId -> {
-            User partner = userRepository.findById(partnerId).orElse(null);
+            User partner = userRepository.findByIdIncludingDeleted(partnerId).orElse(null);
             if (partner == null)
                 return null;
 
@@ -219,7 +219,8 @@ public class SocialService {
                     partner.getEquippedDecorationClass(),
                     lastMessagePreview,
                     lastMessage != null ? lastMessage.getCreatedAt() : null,
-                    unreadCount);
+                    unreadCount,
+                    partner.isDeleted());
         }).filter(java.util.Objects::nonNull).collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/ssafy/dash/social/application/dto/result/ConversationResult.java
+++ b/backend/src/main/java/com/ssafy/dash/social/application/dto/result/ConversationResult.java
@@ -3,30 +3,33 @@ package com.ssafy.dash.social.application.dto.result;
 import java.time.LocalDateTime;
 
 public record ConversationResult(
-        Long partnerId,
-        String partnerName,
-        String partnerAvatar,
-        String partnerDecorationClass,
-        String lastMessagePreview,
-        LocalDateTime lastMessageTime,
-        int unreadCount) {
-    public static ConversationResult of(
-            Long partnerId,
-            String partnerName,
-            String partnerAvatar,
-            String partnerDecorationClass,
-            String lastMessagePreview,
-            LocalDateTime lastMessageTime,
-            int unreadCount) {
-        return new ConversationResult(
-                partnerId,
-                partnerName,
-                partnerAvatar,
-                partnerDecorationClass,
-                lastMessagePreview != null && lastMessagePreview.length() > 50
-                        ? lastMessagePreview.substring(0, 50) + "..."
-                        : lastMessagePreview,
-                lastMessageTime,
-                unreadCount);
-    }
+                Long partnerId,
+                String partnerName,
+                String partnerAvatar,
+                String partnerDecorationClass,
+                String lastMessagePreview,
+                LocalDateTime lastMessageTime,
+                int unreadCount,
+                boolean isPartnerDeleted) {
+        public static ConversationResult of(
+                        Long partnerId,
+                        String partnerName,
+                        String partnerAvatar,
+                        String partnerDecorationClass,
+                        String lastMessagePreview,
+                        LocalDateTime lastMessageTime,
+                        int unreadCount,
+                        boolean isPartnerDeleted) {
+                return new ConversationResult(
+                                partnerId,
+                                partnerName,
+                                partnerAvatar,
+                                partnerDecorationClass,
+                                lastMessagePreview != null && lastMessagePreview.length() > 50
+                                                ? lastMessagePreview.substring(0, 50) + "..."
+                                                : lastMessagePreview,
+                                lastMessageTime,
+                                unreadCount,
+                                isPartnerDeleted);
+        }
 }

--- a/frontend/src/components/social/DirectMessageModal.vue
+++ b/frontend/src/components/social/DirectMessageModal.vue
@@ -16,6 +16,7 @@
                             :nickname="partnerName" 
                             :decorationClass="partnerDecoration"
                             :enable-decoration="true"
+                            :is-deleted="partnerIsDeleted"
                             class="text-base"
                         />
                         <p class="text-xs text-brand-500 font-bold">Online</p>
@@ -57,7 +58,11 @@
             
             <!-- Input Area -->
             <div class="p-4 bg-white border-t border-slate-100 shrink-0">
-                <form @submit.prevent="sendMessage" class="flex items-center gap-2">
+                <div v-if="partnerIsDeleted" class="flex items-center justify-center py-3 bg-slate-50 rounded-xl text-slate-500 font-medium text-sm gap-2">
+                     <AlertCircle :size="18" />
+                     상대방이 탈퇴하여 대화를 보낼 수 없습니다.
+                </div>
+                <form v-else @submit.prevent="sendMessage" class="flex items-center gap-2">
                     <input 
                         v-model="newMessage" 
                         type="text" 
@@ -82,14 +87,15 @@
 <script setup>
 import { ref, onMounted, nextTick, onBeforeUnmount } from 'vue';
 import { socialApi } from '@/api/social';
-import { X, Send, Loader2 } from 'lucide-vue-next';
+import { X, Send, Loader2, AlertCircle } from 'lucide-vue-next';
 import NicknameRenderer from '@/components/common/NicknameRenderer.vue';
 
 const props = defineProps({
     partnerId: Number,
     partnerName: String,
     partnerAvatar: String,
-    partnerDecoration: String
+    partnerDecoration: String,
+    partnerIsDeleted: Boolean
 });
 
 const emit = defineEmits(['close']);

--- a/frontend/src/components/social/FloatingMessagePanel.vue
+++ b/frontend/src/components/social/FloatingMessagePanel.vue
@@ -65,6 +65,7 @@
                                         :decorationClass="conv.partnerDecoration"
                                         :enable-decoration="true"
                                         :show-text="false"
+                                        :is-deleted="conv.isPartnerDeleted"
                                         avatar-class="w-12 h-12 rounded-full object-cover border border-slate-100"
                                     />
                                     <div v-if="conv.isGroup" class="absolute -bottom-1 -right-1 bg-indigo-500 text-white rounded-full p-0.5 border-2 border-white">
@@ -79,6 +80,7 @@
                                                 :decorationClass="conv.partnerDecoration"
                                                 :enable-decoration="true"
                                                 :show-avatar="false"
+                                                :is-deleted="conv.isPartnerDeleted"
                                                 text-class="font-bold text-slate-800 text-sm truncate"
                                             />
                                             <span v-if="conv.isGroup" class="text-xs font-normal text-slate-500 shrink-0">({{ conv.memberCount }})</span>
@@ -134,6 +136,8 @@
                                         :decorationClass="activeChat?.partnerDecoration"
                                         :enable-decoration="true"
                                         :show-text="false"
+                                        :is-deleted="isPartnerDeleted"
+                                        class="shrink-0"
                                         avatar-class="w-8 h-8 rounded-full self-start border border-slate-100"
                                     />
                                     
@@ -152,17 +156,16 @@
                             </div>
                         </template>
 
-                        <div v-if="isPartnerDeleted" class="flex justify-center my-4">
-                            <div class="flex items-center gap-2 px-4 py-2 bg-slate-100 rounded-lg opacity-70">
-                                <AlertCircle :size="14" class="text-slate-500" />
-                                <span class="text-xs text-slate-500">상대방이 탈퇴하여 대화를 보낼 수 없습니다.</span>
-                            </div>
-                        </div>
+
                     </div>
 
                     <!-- 입력창 -->
                     <div class="p-3 bg-white border-t border-slate-100 shrink-0">
-                        <form @submit.prevent="sendMessage" class="relative flex items-end gap-2 bg-slate-50 p-2 rounded-xl border border-slate-200 focus-within:border-brand-300 focus-within:ring-2 focus-within:ring-brand-100 transition-all">
+                        <div v-if="isPartnerDeleted" class="flex items-center justify-center py-3 bg-slate-50 rounded-xl text-slate-500 font-medium text-xs gap-2">
+                            <AlertCircle :size="14" />
+                            상대방이 탈퇴하여 대화를 보낼 수 없습니다.
+                        </div>
+                        <form v-else @submit.prevent="sendMessage" class="relative flex items-end gap-2 bg-slate-50 p-2 rounded-xl border border-slate-200 focus-within:border-brand-300 focus-within:ring-2 focus-within:ring-brand-100 transition-all">
                             <textarea 
                                 ref="dmInputRef"
                                 v-model="newMessage"
@@ -170,11 +173,11 @@
                                 placeholder="메시지를 입력하세요..." 
                                 class="flex-1 bg-transparent border-none focus:ring-0 text-sm p-1 max-h-20 resize-none placeholder:text-slate-400"
                                 rows="1"
-                                :disabled="sending || isPartnerDeleted"
+                                :disabled="sending"
                             ></textarea>
                             <button 
                                 type="submit" 
-                                :disabled="!newMessage.trim() || sending || isPartnerDeleted"
+                                :disabled="!newMessage.trim() || sending"
                                 class="p-2 bg-brand-500 hover:bg-brand-600 active:scale-95 disabled:opacity-50 disabled:active:scale-100 text-white rounded-lg transition-all"
                             >
                                 <Send :size="16" />
@@ -208,6 +211,7 @@
                                     :decorationClass="msg.senderDecoration"
                                     :enable-decoration="true"
                                     :show-text="false"
+                                    class="shrink-0"
                                     avatar-class="w-8 h-8 rounded-full self-start border border-slate-100" 
                                 />
                                 
@@ -415,8 +419,10 @@ const allConversations = computed(() => {
         partnerName: c.partnerName,
         partnerAvatar: c.partnerAvatar,
         lastMessagePreview: c.lastMessagePreview,
+        lastMessagePreview: c.lastMessagePreview,
         lastMessageTime: c.lastMessageTime,
-        unreadCount: c.unreadCount || 0
+        unreadCount: c.unreadCount || 0,
+        isPartnerDeleted: c.isPartnerDeleted
     }));
 
     const groupList = groupRooms.value.map(r => ({

--- a/frontend/src/components/social/UserProfileModal.vue
+++ b/frontend/src/components/social/UserProfileModal.vue
@@ -48,50 +48,53 @@
                     나의 프로필입니다
                 </div>
 
-                <!-- Case: Deleted User -->
-                <div v-else-if="targetUserInfo.isDeleted" class="p-3 bg-rose-50 border border-rose-100 text-rose-600 rounded-xl text-sm font-bold flex items-center justify-center gap-2">
-                    <AlertCircle :size="16"/> 탈퇴한 회원입니다
-                </div>
-
-                <!-- Case: Friend -->
-                <template v-else-if="friendshipStatus === 'ACCEPTED'">
-                    <button 
-                        @click="openDM" 
-                        class="w-full py-3 bg-brand-500 text-white rounded-xl text-sm font-bold hover:bg-brand-600 transition-colors flex items-center justify-center gap-2 shadow-lg shadow-brand-500/20"
-                    >
-                        <MessageCircle :size="18"/> 쪽지 보내기
-                    </button>
-                    <div class="flex items-center justify-between mt-2">
-                        <div class="text-xs text-brand-600 font-bold flex items-center gap-1">
-                            <Users :size="14"/> 서로 친구입니다
-                        </div>
-                        <button 
-                            @click="handleDeleteFriend" 
-                            class="text-xs text-slate-400 hover:text-rose-500 font-bold flex items-center gap-1 transition-colors"
-                        >
-                            <UserMinus :size="14"/> 친구 끊기
-                        </button>
+                <template v-else>
+                    <!-- Case: Deleted User Warning -->
+                    <div v-if="targetUserInfo.isDeleted" class="p-3 bg-rose-50 border border-rose-100 text-rose-600 rounded-xl text-sm font-bold flex items-center justify-center gap-2 mb-3">
+                        <AlertCircle :size="16"/> 탈퇴한 회원입니다
                     </div>
+
+                    <!-- Case: Friend (Visible even if deleted) -->
+                    <template v-if="friendshipStatus === 'ACCEPTED'">
+                        <button 
+                            @click="openDM" 
+                            class="w-full py-3 bg-brand-500 text-white rounded-xl text-sm font-bold hover:bg-brand-600 transition-colors flex items-center justify-center gap-2 shadow-lg shadow-brand-500/20"
+                        >
+                            <MessageCircle :size="18"/> 쪽지 보내기
+                        </button>
+                        <div class="flex items-center justify-between mt-2">
+                            <div class="text-xs text-brand-600 font-bold flex items-center gap-1">
+                                <Users :size="14"/> 서로 친구입니다
+                            </div>
+                            <button 
+                                @click="handleDeleteFriend" 
+                                class="text-xs text-slate-400 hover:text-rose-500 font-bold flex items-center gap-1 transition-colors"
+                            >
+                                <UserMinus :size="14"/> 친구 끊기
+                            </button>
+                        </div>
+                    </template>
+
+                    <!-- Case: Pending / Not Friend (Only if NOT deleted) -->
+                    <template v-else-if="!targetUserInfo.isDeleted">
+                        <button 
+                            v-if="friendshipStatus === 'PENDING' || requested"
+                            disabled
+                            class="w-full py-3 bg-slate-100 text-slate-400 rounded-xl text-sm font-bold cursor-not-allowed flex items-center justify-center gap-2"
+                        >
+                            <CheckCircle2 :size="18"/> 친구 요청 보냄
+                        </button>
+
+                        <button 
+                            v-else
+                            @click="sendFriendRequest"
+                            class="w-full py-3 bg-slate-900 text-white rounded-xl text-sm font-bold hover:bg-slate-800 transition-colors flex items-center justify-center gap-2 shadow-lg shadow-slate-900/10"
+                        >
+                            <UserPlus :size="18"/> 친구 신청
+                        </button>
+                    </template>
                 </template>
-
-                <!-- Case: Pending / Strings attached -->
-                <button 
-                        v-else-if="friendshipStatus === 'PENDING' || requested"
-                        disabled
-                        class="w-full py-3 bg-slate-100 text-slate-400 rounded-xl text-sm font-bold cursor-not-allowed flex items-center justify-center gap-2"
-                    >
-                        <CheckCircle2 :size="18"/> 친구 요청 보냄
-                    </button>
-
-                    <!-- Case: Not Friend -->
-                    <button 
-                        v-else
-                        @click="sendFriendRequest"
-                        class="w-full py-3 bg-slate-900 text-white rounded-xl text-sm font-bold hover:bg-slate-800 transition-colors flex items-center justify-center gap-2 shadow-lg shadow-slate-900/10"
-                    >
-                        <UserPlus :size="18"/> 친구 신청
-                    </button>
-                </div>
+            </div>
 
             </div>
         </div>

--- a/frontend/src/views/social/SocialView.vue
+++ b/frontend/src/views/social/SocialView.vue
@@ -155,11 +155,19 @@
                                             @click="openUserProfile(item.friend)"
                                         >
                                             <div class="flex items-center gap-2.5 min-w-0">
-                                                <img :src="getAvatar(item.friend?.avatarUrl)" class="w-8 h-8 rounded-full border border-slate-200"/>
+                                                <NicknameRenderer 
+                                                    :username="item.friend?.username"
+                                                    :nickname="item.friend?.nickname"
+                                                    :avatar-url="item.friend?.avatarUrl"
+                                                    :decorationClass="item.friend?.equippedDecorationClass"
+                                                    :enable-decoration="true"
+                                                    :is-deleted="item.friend?.isDeleted"
+                                                    avatar-class="w-8 h-8"
+                                                    text-class="text-sm font-bold text-slate-700 truncate"
+                                                />
                                                 <div class="min-w-0">
                                                     <div class="flex items-center gap-1">
-                                                        <span class="text-sm font-bold text-slate-700 truncate">{{ item.friend?.username || '알 수 없음' }}</span>
-                                                        <TierBadge v-if="item.friend?.solvedacTier" :tier="item.friend.solvedacTier" size="xs" :show-roman="false" />
+                                                        <TierBadge v-if="item.friend?.solvedacTier && !item.friend?.isDeleted" :tier="item.friend.solvedacTier" size="xs" :show-roman="false" />
                                                     </div>
                                                 </div>
                                             </div>
@@ -190,6 +198,7 @@ import TierBadge from '@/components/common/TierBadge.vue';
 import FeedItem from '@/components/social/FeedItem.vue';
 import { useFloatingChat } from '@/composables/useFloatingChat';
 import { useUserProfileModal } from '@/composables/useUserProfileModal';
+import NicknameRenderer from '@/components/common/NicknameRenderer.vue';
 
 const route = useRoute();
 const router = useRouter();
@@ -320,7 +329,6 @@ const rejectRequest = async (requestId) => {
 // 액션
 const openDM = (friend) => {
     if (!friend) return; // null/undefined 체크
-    if (friend.isDeleted) return; // 탈퇴 회원 클릭 방지
     openGlobalDM({
         partnerId: friend.id,
         partnerName: friend.username,


### PR DESCRIPTION
## 🚀 작업 배경

- 탈퇴한 회원과의 채팅방이 목록에서 사라져 과거 대화 내용을 확인할 수 없는 문제가 있었습니다.
- 친구 목록에 남은 탈퇴 회원을 삭제(친구 끊기)하거나 프로필을 확인할 수 없는 불편함이 있었습니다.
- 채팅 메시지가 길어질 경우(여러 줄), 프로필 이미지가 찌그러지는 UI 버그가 발견되었습니다.

---

## 🛠️ 주요 변경 사항

- [X] 탈퇴한 회원과의 대화방도 목록에 표시되도록 수정했습니다.
- [X] 퇴한 유저의 채팅방을 **읽기 전용**(Read-Only)으로 접근할 수 있도록 변경했습니다. (메시지 전송은 차단)
- [X] 탈퇴한 회원이라도 친구 상태라면 프로필에서 '**친구 끊기**'가 가능하도록 버튼을 활성화했습니다.
- [X] 모든 컴포넌트에서 탈퇴한 회원은 "탈퇴한 회원" 이름과 기본 아이콘으로 통일되도록 적용했습니다.
- [X] 채팅 메시지 영역에서 Avatar 컴포넌트에 shrink-0 클래스를 추가하여, 긴 메시지에서도 이미지가 찌그러지지 않도록 수정했습니다.
