### PR TITLE
fix: 쉼표를 포함한 타이틀이더라도 시간과 메모리 정보를 안정적으로 수집하도록 변경

### DIFF
--- a/backend/src/main/java/com/ssafy/dash/github/application/GitHubSubmissionMetadataExtractor.java
+++ b/backend/src/main/java/com/ssafy/dash/github/application/GitHubSubmissionMetadataExtractor.java
@@ -19,7 +19,7 @@ public class GitHubSubmissionMetadataExtractor {
     private static final Logger log = LoggerFactory.getLogger(GitHubSubmissionMetadataExtractor.class);
 
     private static final Pattern COMMIT_MESSAGE_PATTERN = Pattern.compile(
-            "\\[(?<difficulty>[^]]+)]\\s*Title\\s*:\\s*(?<title>[^,]+),\\s*Time\\s*:\\s*(?<time>-?[\\d,]+)\\s*ms,\\s*Memory\\s*:\\s*(?<memory>-?[\\d,]+)\\s*KB",
+            "\\[(?<difficulty>[^]]+)]\\s*Title\\s*:\\s*(?<title>.+?),\\s*Time\\s*:\\s*(?<time>-?[\\d,]+)\\s*ms,\\s*Memory\\s*:\\s*(?<memory>-?[\\d,]+)\\s*KB",
             Pattern.CASE_INSENSITIVE);
 
     // Pattern for "문제번호.문제이름" format (e.g., "12865.평범한배낭" or "1000.A+B")

--- a/backend/src/test/java/com/ssafy/dash/github/application/GitHubSubmissionMetadataExtractorTest.java
+++ b/backend/src/test/java/com/ssafy/dash/github/application/GitHubSubmissionMetadataExtractorTest.java
@@ -95,4 +95,19 @@ class GitHubSubmissionMetadataExtractorTest {
         assertThat(metadata.memoryKb()).isEqualTo(1024);
     }
 
+    @Test
+    void extractParsesSweaCommitMessageWithCommasInTitle() {
+        // [D1] Title: 큰 놈, 작은 놈, 같은 놈, Time: 93 ms, Memory: 26752 KB - DashHub
+        String message = "[D1] Title: 큰 놈, 작은 놈, 같은 놈, Time: 93 ms, Memory: 26752 KB - DashHub";
+        String path = "SWEA/D1/2070.큰놈작은놈같은놈/Solution.java";
+
+        GitHubSubmissionMetadataExtractor.SubmissionMetadata metadata = extractor.extract(message, path);
+
+        assertThat(metadata.platform()).isEqualTo("SWEA");
+        assertThat(metadata.difficulty()).isEqualTo("D1");
+        assertThat(metadata.title()).isEqualTo("큰 놈, 작은 놈, 같은 놈");
+        assertThat(metadata.runtimeMs()).isEqualTo(93);
+        assertThat(metadata.memoryKb()).isEqualTo(26752);
+    }
+
 }


### PR DESCRIPTION
## 🚀 작업 배경

정규표현식에 허점이 있어 성공 기록을 실패로 취급하는 이슈가 발생했습니다.

---

## 🛠️ 주요 변경 사항

- [x] 타이틀에 쉼표가 포함되어 있더라도 성공/실패를 정상적으로 판단합니다.

---

## 🔗 관련 이슈

- 이메일 제보