### PR TITLE
refactor: 마이페이지 속도 개선 & 추천 스터디 범위 축소

### DIFF
--- a/backend/src/main/java/com/ssafy/dash/analytics/application/SolvedacSyncService.java
+++ b/backend/src/main/java/com/ssafy/dash/analytics/application/SolvedacSyncService.java
@@ -11,13 +11,13 @@ import com.ssafy.dash.solvedac.domain.TagStat;
 import com.ssafy.dash.solvedac.domain.Top100Problem;
 import com.ssafy.dash.user.domain.User;
 import com.ssafy.dash.user.domain.UserRepository;
+import com.ssafy.dash.ai.infrastructure.persistence.LearningPathCacheMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
-
-import com.ssafy.dash.ai.infrastructure.persistence.LearningPathCacheMapper;
 
 @Slf4j
 @Service
@@ -188,7 +188,7 @@ public class SolvedacSyncService {
      * 사용자 티어 및 기본 스탯 경량 동기화 (Lazy Sync용)
      * Bio 인증 없이 API 정보만 가져와서 갱신
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateTierAndStats(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));

--- a/backend/src/main/java/com/ssafy/dash/user/application/UserService.java
+++ b/backend/src/main/java/com/ssafy/dash/user/application/UserService.java
@@ -154,9 +154,9 @@ public class UserService {
         if (user.getSolvedacHandle() == null || user.getSolvedacHandle().isBlank()) {
             return false;
         }
-        // 1시간(60분)이 지났으면 갱신
+        // 12시간이 지났으면 갱신
         return user.getStatsLastSyncedAt() == null ||
-                user.getStatsLastSyncedAt().isBefore(LocalDateTime.now().minusMinutes(60));
+                user.getStatsLastSyncedAt().isBefore(LocalDateTime.now().minusHours(12));
     }
 
 }

--- a/frontend/src/components/study/StudyExplorer.vue
+++ b/frontend/src/components/study/StudyExplorer.vue
@@ -223,7 +223,7 @@
                  <div class="w-14 h-14 bg-slate-50 rounded-full flex items-center justify-center mx-auto mb-4 border border-slate-100">
                     <Search class="w-6 h-6 text-slate-300" />
                  </div>
-                 <p class="text-slate-600 font-bold mb-1 text-sm">내 티어(±5)와 비슷한 스터디가 존재하지 않습니다</p>
+                 <p class="text-slate-600 font-bold mb-1 text-sm">내 티어(±1)와 비슷한 스터디가 존재하지 않습니다</p>
              </div>
         </div>
       </div>
@@ -648,9 +648,9 @@ const recommendedStudies = computed(() => {
     // 내 스터디 제외
     if (study.id === user.value.studyId) return false;
 
-    // 내 티어 기준 ±5 범위 내
+    // 내 티어 기준 ±1 범위 내
     const diff = Math.abs(study.averageTier - userTier);
-    return diff <= 5;
+    return diff <= 1;
   });
 });
 


### PR DESCRIPTION
## 🚀 작업 배경

`UserService.findById`는 읽기 전용 모드(`@Transactional(readOnly=true)`)로 실행됩니다.
여기서 동기화 로직을 호출하니 "마지막 갱신 시간 업데이트"가 DB에 반영되지 않고 무시되고 있었습니다.
이에 따라 1시간이 안 지났는데도 지난 줄 알고 매번 API를 호출해서 느려지고 있어 조치가 필요합니다.

핫픽스를 진행하는 김에 추천 스터디 범위 축소도 같이 진행해야 합니다.

---

## 🛠️ 주요 변경 사항

- [x] 동기화 메서드는 무조건 새로운 트랜잭션(`REQUIRES_NEW`)으로 실행하도록 강제하였습니다.
- [x] 티어 동기화를 위한 간격 조건을 1시간에서 12시간으로 증가시켰습니다.
- [x] 기존 추천 스터디 범위를 `+-1`로 축소하였습니다.

---

## 🔗 관련 이슈

- Closes #116 