### PR TITLE
feat: 스터디 설정 및 관리 기능 구현 (정보 수정, 위임, 해체)

### DIFF
--- a/backend/src/main/java/com/ssafy/dash/study/application/StudyService.java
+++ b/backend/src/main/java/com/ssafy/dash/study/application/StudyService.java
@@ -12,6 +12,9 @@ import com.ssafy.dash.user.presentation.dto.response.UserResponse;
 import com.ssafy.dash.notification.application.NotificationService;
 import com.ssafy.dash.notification.domain.NotificationType;
 import com.ssafy.dash.study.domain.Study.StudyType;
+import com.ssafy.dash.common.exception.BusinessException;
+import com.ssafy.dash.common.exception.ErrorCode;
+import com.ssafy.dash.user.domain.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -101,7 +104,7 @@ public class StudyService {
     @Transactional
     public Study createStudy(Long userId, String name, String description, StudyVisibility visibility) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(userId));
 
         // 스터디 이동(Transition): 이미 다른 Group 스터디에 있다면, 탈퇴 또는 삭제 처리
         if (user.getStudyId() != null) {
@@ -151,7 +154,7 @@ public class StudyService {
     @Transactional
     public Study createPersonalStudy(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(userId));
 
         if (user.getStudyId() != null) {
             return studyRepository.findById(user.getStudyId()).orElse(null);
@@ -172,13 +175,13 @@ public class StudyService {
     @Transactional
     public void applyForStudy(Long userId, Long studyId, String message) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(userId));
 
         // 스터디 이동 로직은 승인 시점에 처리됩니다. (applyForStudy에서는 체크하지 않음)
 
         // 스터디 존재 여부 확인
         if (studyRepository.findById(studyId).isEmpty()) {
-            throw new IllegalArgumentException("Study not found");
+            throw new BusinessException(ErrorCode.RESOURCE_NOT_FOUND);
         }
 
         // 이미 가입 신청했는지 확인
@@ -206,10 +209,10 @@ public class StudyService {
     @Transactional(readOnly = true)
     public List<StudyApplication> getPendingApplications(Long userId, Long studyId) {
         Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (!Objects.equals(study.getCreatorId(), userId)) {
-            throw new SecurityException("Only creator can view applications");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         return studyRepository.findPendingApplicationsByStudyId(studyId);
@@ -223,10 +226,10 @@ public class StudyService {
     @Transactional
     public void cancelApplication(Long userId, Long applicationId) {
         StudyApplication application = studyRepository.findApplicationById(applicationId)
-                .orElseThrow(() -> new IllegalArgumentException("Application not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (!Objects.equals(application.getUserId(), userId)) {
-            throw new SecurityException("Cannot cancel other's application");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         application.reject();
@@ -236,18 +239,18 @@ public class StudyService {
     @Transactional
     public void approveApplication(Long adminId, Long applicationId) {
         StudyApplication application = studyRepository.findApplicationById(applicationId)
-                .orElseThrow(() -> new IllegalArgumentException("Application not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         Study study = studyRepository.findById(application.getStudyId())
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (!Objects.equals(study.getCreatorId(), adminId)) {
-            throw new SecurityException("Only creator can approve applications");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         // 유저를 스터디에 추가
         User user = userRepository.findById(application.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(application.getUserId()));
 
         // 탈퇴한 유저인지 확인
         if (user.isDeleted()) {
@@ -314,13 +317,13 @@ public class StudyService {
     @Transactional
     public void rejectApplication(Long leaderId, Long applicationId, String reason) {
         StudyApplication application = studyRepository.findApplicationById(applicationId)
-                .orElseThrow(() -> new IllegalArgumentException("Application not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         Study study = studyRepository.findById(application.getStudyId())
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (!Objects.equals(study.getCreatorId(), leaderId)) {
-            throw new SecurityException("Only creator can reject applications");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         // DB에서 삭제하여 재가입 가능하도록 함
@@ -342,7 +345,7 @@ public class StudyService {
     @Transactional
     public void leaveStudy(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(userId));
 
         if (user.getStudyId() == null) {
             throw new IllegalStateException("User is not in a study");
@@ -350,7 +353,7 @@ public class StudyService {
 
         Long oldStudyId = user.getStudyId();
         Study study = studyRepository.findById(oldStudyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (Objects.equals(study.getCreatorId(), userId)) {
             // 정책: 스터디장은 탈퇴할 수 없음. 스터디를 해체하거나 권한을 위임해야 함. (아직 구현되지 않음)
@@ -385,10 +388,14 @@ public class StudyService {
     @Transactional
     public void updateStudy(Long userId, Long studyId, String name, String description) {
         Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
-        if (!java.util.Objects.equals(study.getCreatorId(), userId)) {
-            throw new SecurityException("Only creator can update the study");
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        boolean isAdmin = "ROLE_ADMIN".equals(user.getRole());
+        if (!java.util.Objects.equals(study.getCreatorId(), userId) && !isAdmin) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         if (name != null && !name.isBlank()) {
@@ -404,15 +411,15 @@ public class StudyService {
     @Transactional
     public void deleteStudy(Long userId, Long studyId) {
         Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(userId));
 
         // 스터디장 또는 관리자만 삭제 가능
         boolean isAdmin = "ROLE_ADMIN".equals(user.getRole());
         if (!Objects.equals(study.getCreatorId(), userId) && !isAdmin) {
-            throw new SecurityException("Only creator or admin can delete the study");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         // 1. 모든 멤버를 각자의 Personal 스터디로 쫓아냄
@@ -439,7 +446,7 @@ public class StudyService {
     @Transactional(readOnly = true)
     public List<UserResponse> getStudyMembers(Long studyId) {
         Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         return userRepository.findByStudyId(studyId).stream()
                 .map(user -> UserResult.from(user, null, study))
@@ -458,17 +465,21 @@ public class StudyService {
     @Transactional
     public void delegateLeader(Long currentLeaderId, Long studyId, Long newLeaderId) {
         Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
-        if (!Objects.equals(study.getCreatorId(), currentLeaderId)) {
-            throw new SecurityException("Only creator can delegate the leader role");
+        User user = userRepository.findById(currentLeaderId)
+                .orElseThrow(() -> new UserNotFoundException(currentLeaderId));
+
+        boolean isAdmin = "ROLE_ADMIN".equals(user.getRole());
+        if (!Objects.equals(study.getCreatorId(), currentLeaderId) && !isAdmin) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         User newLeader = userRepository.findById(newLeaderId)
-                .orElseThrow(() -> new IllegalArgumentException("New leader not found"));
+                .orElseThrow(() -> new UserNotFoundException(newLeaderId));
 
         if (!Objects.equals(newLeader.getStudyId(), studyId)) {
-            throw new IllegalArgumentException("New leader must be a member of the study");
+            throw new BusinessException(ErrorCode.VALIDATION_FAILED);
         }
 
         study.setCreatorId(newLeaderId);
@@ -485,13 +496,13 @@ public class StudyService {
     @Transactional(readOnly = true)
     public StudyApplication getApplicationDetail(Long userId, Long applicationId) {
         StudyApplication app = studyRepository.findApplicationById(applicationId)
-                .orElseThrow(() -> new IllegalArgumentException("Application not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         Study study = studyRepository.findById(app.getStudyId())
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (!Objects.equals(study.getCreatorId(), userId)) {
-            throw new SecurityException("Only creator can view application details");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         return app;

--- a/backend/src/main/java/com/ssafy/dash/study/application/StudyService.java
+++ b/backend/src/main/java/com/ssafy/dash/study/application/StudyService.java
@@ -383,6 +383,25 @@ public class StudyService {
     }
 
     @Transactional
+    public void updateStudy(Long userId, Long studyId, String name, String description) {
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+
+        if (!java.util.Objects.equals(study.getCreatorId(), userId)) {
+            throw new SecurityException("Only creator can update the study");
+        }
+
+        if (name != null && !name.isBlank()) {
+            study.setName(name);
+        }
+        if (description != null) {
+            study.setDescription(description);
+        }
+
+        studyRepository.update(study);
+    }
+
+    @Transactional
     public void deleteStudy(Long userId, Long studyId) {
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new IllegalArgumentException("Study not found"));

--- a/backend/src/main/java/com/ssafy/dash/study/presentation/StudyController.java
+++ b/backend/src/main/java/com/ssafy/dash/study/presentation/StudyController.java
@@ -6,6 +6,7 @@ import com.ssafy.dash.study.application.StudyMissionService;
 import com.ssafy.dash.study.application.StudyService;
 import com.ssafy.dash.study.domain.Study;
 import com.ssafy.dash.study.presentation.dto.CreateStudyRequest;
+import com.ssafy.dash.study.presentation.dto.UpdateStudyRequest;
 import com.ssafy.dash.study.presentation.dto.request.ApplyStudyRequest;
 import com.ssafy.dash.study.presentation.dto.request.CreateMissionRequest;
 import com.ssafy.dash.study.presentation.dto.request.AddMissionProblemsRequest;
@@ -97,6 +98,19 @@ public class StudyController {
         if (principal instanceof CustomOAuth2User customUser) {
             Study study = studyService.createPersonalStudy(customUser.getUserId());
             return ResponseEntity.ok(CreateStudyResponse.from(study));
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @Operation(summary = "스터디 정보 수정", description = "스터디의 이름이나 소개를 수정합니다.")
+    @PatchMapping("/{studyId}")
+    public ResponseEntity<Void> updateStudy(
+            @Parameter(hidden = true) @AuthenticationPrincipal OAuth2User principal,
+            @PathVariable Long studyId,
+            @RequestBody UpdateStudyRequest request) {
+        if (principal instanceof CustomOAuth2User customUser) {
+            studyService.updateStudy(customUser.getUserId(), studyId, request.getName(), request.getDescription());
+            return ResponseEntity.ok().build();
         }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }

--- a/backend/src/main/java/com/ssafy/dash/study/presentation/dto/UpdateStudyRequest.java
+++ b/backend/src/main/java/com/ssafy/dash/study/presentation/dto/UpdateStudyRequest.java
@@ -1,0 +1,13 @@
+package com.ssafy.dash.study.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateStudyRequest {
+    private String name;
+    private String description;
+}

--- a/backend/src/main/java/com/ssafy/dash/study/presentation/dto/response/StudyListResponse.java
+++ b/backend/src/main/java/com/ssafy/dash/study/presentation/dto/response/StudyListResponse.java
@@ -22,7 +22,8 @@ public record StudyListResponse(
         LocalDate streakUpdatedAt, // streak 유효성 판단용
         Double averageSubmissionRate,
         List<MemberPreview> memberPreviews, // 멤버 미리보기 (프론트에서 표시 개수 조절)
-        String description) {
+        String description,
+        Long creatorId) {
 
     public static StudyListResponse from(Study study, List<User> members) {
         List<MemberPreview> previews = members != null
@@ -44,7 +45,8 @@ public record StudyListResponse(
                 study.getStreakUpdatedAt(),
                 study.getAverageSubmissionRate() != null ? study.getAverageSubmissionRate() : 0.0,
                 previews,
-                study.getDescription());
+                study.getDescription(),
+                study.getCreatorId());
     }
 
     private static String getTierBadge(Double tier) {

--- a/frontend/src/api/study.js
+++ b/frontend/src/api/study.js
@@ -25,6 +25,10 @@ export const studyApi = {
     get(studyId) {
         return http.get(`/studies/${studyId}`);
     },
+    // Update study details
+    update(studyId, data) {
+        return http.patch(`/studies/${studyId}`, data);
+    },
     // Get acorn logs
     getAcornLogs(studyId) {
         return http.get(`/studies/${studyId}/acorns`);

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -127,6 +127,12 @@ const routes = [
     meta: { requiresAuth: true }
   },
   {
+    path: "/study/manage",
+    name: "StudyManage",
+    component: () => import("../views/study/StudyManageView.vue"),
+    meta: { requiresAuth: true }
+  },
+  {
     path: "/admin/study/:id/dashboard",
     name: "AdminStudyDashboard",
     component: Dashboard,

--- a/frontend/src/views/study/StudyManageView.vue
+++ b/frontend/src/views/study/StudyManageView.vue
@@ -1,0 +1,392 @@
+<script setup>
+import { ref, onMounted, computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { studyApi } from '@/api/study';
+import { useAuth } from '@/composables/useAuth';
+import { 
+  Settings, Users, Crown, Trash2, UserCheck, 
+  ChevronLeft, Loader2, Save, AlertTriangle, X, Check
+} from 'lucide-vue-next';
+import BaseIconBadge from '@/components/common/BaseIconBadge.vue';
+
+const router = useRouter();
+const { user, refresh } = useAuth();
+
+// State
+const loading = ref(true);
+const saving = ref(false);
+const study = ref({
+  id: null,
+  name: '',
+  description: '',
+  creatorId: null
+});
+
+// Member Management
+const memberList = ref([]);
+const loadingMembers = ref(false);
+const showDelegateModal = ref(false);
+const selectedMemberId = ref(null);
+
+// Dissolution
+const showDeleteConfirmModal = ref(false);
+const deleteInput = ref('');
+
+onMounted(async () => {
+  if (!user.value?.studyId) {
+    router.replace('/training/roadmap');
+    return;
+  }
+
+  try {
+    const res = await studyApi.get(user.value.studyId);
+    study.value = res.data;
+    
+    // Check leadership
+    if (study.value.creatorId !== user.value.id && user.value.role !== 'ROLE_ADMIN') {
+      alert("스터디장만 접근 가능합니다.");
+      router.replace('/dashboard');
+    }
+  } catch (e) {
+    console.error("Failed to load study info", e);
+    alert("스터디 정보를 불러오지 못했습니다.");
+    router.replace('/dashboard');
+  } finally {
+    loading.value = false;
+  }
+});
+
+const handleSave = async () => {
+  if (!study.value.name.trim()) return;
+  saving.value = true;
+  try {
+    await studyApi.update(study.value.id, {
+      name: study.value.name,
+      description: study.value.description
+    });
+    alert("스터디 정보가 수정되었습니다.");
+    await refresh(); 
+    router.push('/profile');
+  } catch (e) {
+    console.error(e);
+    alert("수정에 실패했습니다.");
+  } finally {
+    saving.value = false;
+  }
+};
+
+const openDelegateModal = async () => {
+  showDelegateModal.value = true;
+  loadingMembers.value = true;
+  selectedMemberId.value = null;
+  try {
+    const res = await studyApi.getMembers(study.value.id);
+    // Exclude self
+    memberList.value = res.data.filter(m => m.id !== user.value.id);
+  } catch (e) {
+    console.error(e);
+    alert("멤버 목록을 불러오지 못했습니다.");
+    showDelegateModal.value = false;
+  } finally {
+    loadingMembers.value = false;
+  }
+};
+
+const handleDelegate = async () => {
+  if (!selectedMemberId.value) return;
+  if (!confirm("정말로 스터디장 권한을 위임하시겠습니까?\n위임 후에는 일반 멤버로 전환되며, 이 페이지에 다시 접근할 수 없습니다.")) return;
+  
+  try {
+    await studyApi.delegateLeader(study.value.id, selectedMemberId.value);
+    alert("스터디장이 변경되었습니다.");
+    router.replace('/profile');
+  } catch(e) {
+    console.error(e);
+    alert("위임에 실패했습니다.");
+  }
+};
+
+const openDeleteModal = () => {
+  deleteInput.value = '';
+  showDeleteConfirmModal.value = true;
+};
+
+const handleConfirmDelete = async () => {
+  if (deleteInput.value !== study.value.name) return;
+  
+  if (!confirm("정말로 스터디를 해체하시겠습니까?\n이 작업은 되돌릴 수 없으며, 모든 미션과 기록이 영구적으로 삭제됩니다.")) return;
+  
+  try {
+    await studyApi.deleteStudy(study.value.id);
+    alert("스터디가 해체되었습니다.");
+    router.replace('/training/roadmap');
+  } catch (e) {
+    console.error(e);
+    alert(e.response?.data?.message || "해체에 실패했습니다.");
+  }
+};
+
+const goBack = () => {
+  router.back();
+};
+</script>
+
+<template>
+  <div class="min-h-screen bg-slate-50 text-slate-700 font-[Pretendard] pb-20">
+    <!-- Header -->
+    <header class="bg-white border-b border-slate-200 sticky top-0 z-30">
+      <div class="container mx-auto px-6 h-16 flex items-center justify-between max-w-5xl">
+        <div class="flex items-center gap-4">
+          <button @click="goBack" class="p-2 hover:bg-slate-100 rounded-xl transition-colors text-slate-500">
+            <ChevronLeft :size="24" />
+          </button>
+          <h1 class="text-xl font-black text-slate-800 tracking-tight">스터디 관리</h1>
+        </div>
+        <button 
+          @click="handleSave"
+          :disabled="saving || !study.name.trim()"
+          class="px-5 py-2.5 bg-brand-600 hover:bg-brand-700 text-white rounded-xl font-bold transition-all shadow-md shadow-brand-200 disabled:opacity-50 flex items-center gap-2"
+        >
+          <Loader2 v-if="saving" class="animate-spin w-4 h-4" />
+          <Save v-else :size="18" />
+          저장하기
+        </button>
+      </div>
+    </header>
+
+    <main class="container mx-auto px-6 py-10 max-w-5xl">
+      <div v-if="loading" class="flex flex-col items-center justify-center py-20">
+        <Loader2 class="animate-spin text-brand-500 mb-4" :size="48" />
+        <p class="text-slate-400 font-bold">스터디 정보를 불러오는 중...</p>
+      </div>
+
+      <div v-else class="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">
+        <!-- Left Side: Basic Info -->
+        <div class="lg:col-span-7 space-y-6">
+          <section class="bg-white rounded-3xl p-8 shadow-sm border border-slate-100">
+            <h2 class="text-lg font-bold text-slate-800 mb-6 flex items-center gap-2">
+              <Settings :size="20" class="text-brand-500" />
+              기본 정보 수정
+            </h2>
+            
+            <div class="space-y-6">
+              <div>
+                <label class="block text-xs font-bold text-slate-400 mb-2 uppercase">스터디 이름</label>
+                <input 
+                  v-model="study.name"
+                  type="text"
+                  placeholder="스터디 이름을 입력하세요"
+                  class="w-full bg-slate-50 border-2 border-slate-100 rounded-2xl px-4 py-3.5 font-bold text-slate-700 focus:outline-none focus:border-brand-500 focus:bg-white transition-all"
+                />
+              </div>
+
+              <div>
+                <label class="block text-xs font-bold text-slate-400 mb-2 uppercase">스터디 소개</label>
+                <textarea 
+                  v-model="study.description"
+                  rows="4"
+                  placeholder="스터디를 소개하는 글을 적어주세요"
+                  class="w-full bg-slate-50 border-2 border-slate-100 rounded-2xl px-4 py-3.5 font-medium text-slate-700 focus:outline-none focus:border-brand-500 focus:bg-white transition-all resize-none"
+                ></textarea>
+              </div>
+            </div>
+          </section>
+
+          <!-- Integration Tips -->
+          <div class="bg-indigo-50 border border-indigo-100 rounded-3xl p-6 flex gap-4">
+            <div class="bg-indigo-100 p-3 rounded-2xl h-fit">
+              <Settings class="w-6 h-6 text-indigo-600" />
+            </div>
+            <div>
+              <h3 class="font-bold text-indigo-900 mb-1">스터디 관리 팁</h3>
+              <p class="text-sm text-indigo-700 leading-relaxed break-keep">
+                <span class="block">스터디 이름이나 소개글을 변경하면 모든 스터디원에게 즉시 반영됩니다.</span>
+                <span class="block">멋진 소개글로 새로운 팀원을 모집해보세요!</span>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Right Side: Leader Actions -->
+        <div class="lg:col-span-5 space-y-6">
+          <section class="bg-white rounded-3xl p-8 shadow-sm border border-slate-100">
+            <h2 class="text-lg font-bold text-slate-800 mb-6 flex items-center gap-2">
+              <Crown :size="20" class="text-orange-500" />
+              스터디장 전용 작업
+            </h2>
+
+            <div class="space-y-4">
+              <!-- Delegation -->
+              <button 
+                @click="openDelegateModal"
+                class="w-full group px-6 py-5 bg-slate-50 hover:bg-brand-50 border border-slate-100 hover:border-brand-100 rounded-2xl transition-all text-left flex items-center justify-between"
+              >
+                <div class="flex items-center gap-4">
+                  <div class="p-3 bg-white group-hover:bg-brand-100 rounded-xl transition-colors shadow-sm">
+                    <UserCheck :size="20" class="text-slate-400 group-hover:text-brand-600" />
+                  </div>
+                  <div>
+                    <div class="font-bold text-slate-700 group-hover:text-brand-900">스터디장 위임</div>
+                    <div class="text-xs text-slate-400 group-hover:text-brand-600">권한을 다른 멤버에게 넘깁니다</div>
+                  </div>
+                </div>
+              </button>
+
+              <!-- Dissolution -->
+              <button 
+                @click="openDeleteModal"
+                class="w-full group px-6 py-5 bg-slate-50 hover:bg-red-50 border border-slate-100 hover:border-red-100 rounded-2xl transition-all text-left flex items-center justify-between"
+              >
+                <div class="flex items-center gap-4">
+                  <div class="p-3 bg-white group-hover:bg-red-100 rounded-xl transition-colors shadow-sm">
+                    <Trash2 :size="20" class="text-slate-400 group-hover:text-red-500" />
+                  </div>
+                  <div>
+                    <div class="font-bold text-slate-700 group-hover:text-red-900">스터디 해체</div>
+                    <div class="text-xs text-slate-400 group-hover:text-red-500">모든 정보와 기록을 삭제합니다</div>
+                  </div>
+                </div>
+              </button>
+            </div>
+          </section>
+
+          <!-- Warning Zone -->
+          <div class="bg-amber-50 border border-amber-100 rounded-3xl p-6 flex gap-4">
+            <AlertTriangle class="w-6 h-6 text-amber-500 shrink-0" />
+            <p class="text-xs text-amber-700 font-medium leading-relaxed break-keep">
+              <span class="block">스터디장 권한 위임이나 스터디 해체는 되돌릴 수 없는 작업입니다.</span>
+              <span class="block">신중하게 결정해주세요.</span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Delegation Modal -->
+    <Teleport to="body">
+      <div v-if="showDelegateModal" class="fixed inset-0 z-[9000] flex items-center justify-center p-4">
+        <div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" @click="showDelegateModal = false"></div>
+        <div class="relative bg-white rounded-3xl w-full max-w-md p-8 shadow-2xl animate-in fade-in zoom-in-95 duration-200">
+          <div class="flex items-center justify-between mb-6">
+            <h3 class="text-xl font-bold text-slate-800">스터디장 위임</h3>
+            <button @click="showDelegateModal = false" class="p-2 hover:bg-slate-100 rounded-full transition-colors">
+              <X :size="20" class="text-slate-400" />
+            </button>
+          </div>
+          
+          <p class="text-sm text-slate-500 mb-6">새로운 스터디장을 선택해주세요.</p>
+          
+          <div v-if="loadingMembers" class="py-12 flex flex-col items-center gap-3 mb-10">
+            <Loader2 class="animate-spin text-brand-500" :size="32"/>
+            <p class="text-xs text-slate-400 font-bold">멤버 목록 불러오는 중...</p>
+          </div>
+          
+          <div v-else-if="memberList.length === 0" class="py-12 text-center text-slate-400 font-bold bg-slate-50 rounded-2xl px-6 mb-10">
+            <Users class="w-12 h-12 text-slate-200 mx-auto mb-3" />
+            위임할 수 있는 다른 멤버가 없습니다.<br>
+            <span class="text-xs font-normal mt-2 block">멤버가 최소 2명 이상이어야 위임이 가능합니다.</span>
+          </div>
+
+          <div v-else class="space-y-3 max-h-[300px] overflow-y-auto mb-10 pr-1 custom-scrollbar">
+            <label 
+              v-for="member in memberList" 
+              :key="member.id"
+              class="flex items-center gap-4 p-4 rounded-2xl border-2 cursor-pointer transition-all"
+              :class="selectedMemberId === member.id ? 'border-brand-500 bg-brand-50 shadow-sm shadow-brand-100' : 'border-slate-50 hover:border-slate-200'"
+            >
+              <input type="radio" :value="member.id" v-model="selectedMemberId" class="hidden">
+              <img :src="member.avatarUrl || '/images/profiles/default-profile.png'" class="w-12 h-12 rounded-2xl bg-slate-100 object-cover border border-slate-100 shadow-sm" />
+              <div class="flex-1">
+                <div class="font-bold text-slate-700">{{ member.username }}</div>
+                <div class="text-xs text-slate-400">Tier: {{ member.solvedacTier }}</div>
+              </div>
+              <div v-if="selectedMemberId === member.id" class="w-6 h-6 bg-brand-500 text-white rounded-full flex items-center justify-center">
+                <Check :size="14" stroke-width="3" />
+              </div>
+            </label>
+          </div>
+
+          <div class="flex gap-3">
+            <button 
+                @click="showDelegateModal = false"
+                class="flex-1 py-4 rounded-2xl font-bold text-slate-500 border border-slate-200 hover:bg-slate-50 transition-colors"
+            >
+                취소
+            </button>
+            <button 
+                @click="handleDelegate"
+                :disabled="!selectedMemberId"
+                class="flex-1 py-4 rounded-2xl font-bold text-white bg-brand-400 hover:bg-brand-500 transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-brand-100"
+            >
+                위임하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Dissolution Confirmation Modal -->
+    <Teleport to="body">
+      <div v-if="showDeleteConfirmModal" class="fixed inset-0 z-[9000] flex items-center justify-center p-4">
+        <div class="absolute inset-0 bg-slate-900/70 backdrop-blur-sm" @click="showDeleteConfirmModal = false"></div>
+        <div class="relative bg-white rounded-3xl w-full max-w-lg p-8 shadow-2xl animate-in fade-in zoom-in-95 duration-200 border border-red-50">
+          <h3 class="text-2xl font-black text-slate-800 mb-2">스터디 해체</h3>
+          <p class="text-sm text-slate-500 leading-relaxed mb-8 break-keep">
+            <span class="block">정말 <span class="bg-red-50 text-red-600 px-1.5 py-0.5 rounded font-bold underline decoration-2 underline-offset-4">{{ study.name }}</span> 스터디를 해체하시겠습니까?</span>
+            <span class="block">이 작업은 되돌릴 수 없으며, 모든 미션과 기록이 영구적으로 삭제됩니다.</span>
+          </p>
+          
+          <div class="mb-8">
+            <label class="block text-xs font-bold text-slate-400 mb-3 uppercase tracking-widest">스터디 이름을 입력하세요</label>
+            <input 
+              v-model="deleteInput"
+              type="text"
+              class="w-full bg-slate-50 border-2 border-slate-100 rounded-2xl px-5 py-4 font-black text-slate-800 focus:outline-none focus:border-red-500 focus:bg-white transition-all placeholder:text-slate-200"
+              :placeholder="study.name"
+            />
+          </div>
+
+          <div class="flex gap-4">
+            <button 
+              @click="showDeleteConfirmModal = false"
+              class="flex-1 py-4 rounded-2xl font-bold text-slate-500 border border-slate-200 hover:bg-slate-50 transition-colors"
+            >
+              취소
+            </button>
+            <button 
+              @click="handleConfirmDelete"
+              :disabled="deleteInput !== study.name"
+              class="flex-1 py-4 rounded-2xl font-bold text-white bg-red-500 hover:bg-red-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-red-200"
+            >
+              해체하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<style scoped>
+.custom-scrollbar::-webkit-scrollbar {
+  width: 4px;
+}
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #e2e8f0;
+  border-radius: 10px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #cbd5e1;
+}
+
+/* Base Decoration Classes (from project CSS if available) */
+.text-brand-gradient {
+  background: linear-gradient(to right, #6366f1, #06b6d4);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+</style>

--- a/frontend/src/views/study/StudyManageView.vue
+++ b/frontend/src/views/study/StudyManageView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { studyApi } from '@/api/study';
 import { useAuth } from '@/composables/useAuth';
@@ -7,7 +7,6 @@ import {
   Settings, Users, Crown, Trash2, UserCheck, 
   ChevronLeft, Loader2, Save, AlertTriangle, X, Check
 } from 'lucide-vue-next';
-import BaseIconBadge from '@/components/common/BaseIconBadge.vue';
 
 const router = useRouter();
 const { user, refresh } = useAuth();
@@ -46,6 +45,14 @@ onMounted(async () => {
     if (study.value.creatorId !== user.value.id && user.value.role !== 'ROLE_ADMIN') {
       alert("스터디장만 접근 가능합니다.");
       router.replace('/dashboard');
+      return;
+    }
+
+    // Block personal study management
+    if (study.value.studyType === 'PERSONAL') {
+      alert("개인 연구실은 관리할 수 없습니다.");
+      router.replace('/dashboard');
+      return;
     }
   } catch (e) {
     console.error("Failed to load study info", e);
@@ -98,6 +105,7 @@ const handleDelegate = async () => {
   
   try {
     await studyApi.delegateLeader(study.value.id, selectedMemberId.value);
+    await refresh();
     alert("스터디장이 변경되었습니다.");
     router.replace('/profile');
   } catch(e) {
@@ -118,6 +126,7 @@ const handleConfirmDelete = async () => {
   
   try {
     await studyApi.deleteStudy(study.value.id);
+    await refresh();
     alert("스터디가 해체되었습니다.");
     router.replace('/training/roadmap');
   } catch (e) {

--- a/frontend/src/views/user/ProfileView.vue
+++ b/frontend/src/views/user/ProfileView.vue
@@ -13,70 +13,12 @@ import TroubleshootingModal from '@/components/common/TroubleshootingModal.vue';
 const router = useRouter();
 const { refresh, user, logout } = useAuth();
 
+const goToStudyManage = () => {
+    router.push('/study/manage');
+};
+
 // 스터디 메뉴 상태
 const showStudyMenu = ref(false);
-
-// 위임 모달 상태
-const showDelegateModal = ref(false);
-const memberList = ref([]);
-const loadingMembers = ref(false);
-const selectedMemberId = ref(null);
-
-const openDelegateModal = async () => {
-    showDelegateModal.value = true;
-    loadingMembers.value = true;
-    selectedMemberId.value = null; // reset selection
-    try {
-        const res = await studyApi.getMembers(userData.value.studyId);
-        // Exclude self
-        memberList.value = res.data.filter(m => m.id !== userData.value.id);
-    } catch (e) {
-        console.error(e);
-        alert("멤버 목록을 불러오지 못했습니다.");
-        showDelegateModal.value = false;
-    } finally {
-        loadingMembers.value = false;
-    }
-};
-
-const handleDelegate = async () => {
-    if (!selectedMemberId.value) return;
-    if (!confirm("정말로 스터디장 권한을 위임하시겠습니까?\n위임 후에는 일반 멤버로 전환됩니다.")) return;
-    try {
-        await studyApi.delegateLeader(userData.value.studyId, selectedMemberId.value);
-        alert("스터디장이 변경되었습니다.");
-        window.location.reload();
-    } catch(e) {
-        console.error(e);
-        alert("위임에 실패했습니다.");
-    }
-};
-
-// 삭제 모달 상태
-const showDeleteConfirmModal = ref(false);
-const deleteInput = ref('');
-
-const openDeleteModal = () => {
-    if (userData.value.studyType === 'PERSONAL') {
-        alert("임시 스터디(Personal Study)는 직접 삭제할 수 없습니다.\n새로운 스터디를 생성하거나 다른 스터디에 가입하면 자동으로 정리됩니다.");
-        return;
-    }
-    deleteInput.value = '';
-    showDeleteConfirmModal.value = true;
-};
-
-const handleConfirmDelete = async () => {
-    if (deleteInput.value !== studyName.value) return;
-    
-    try {
-        await studyApi.deleteStudy(userData.value.studyId);
-        alert("스터디가 해체되었습니다.");
-        window.location.reload();
-    } catch (e) {
-        console.error(e);
-        alert(e.response?.data?.message || "해체에 실패했습니다.");
-    }
-};
 
 // ... (userData definition)
 
@@ -270,6 +212,7 @@ const handleDelete = async () => {
     }
 };
 
+// 스터디 탈퇴는 남겨둠 (일반 멤버용)
 const handleLeaveStudy = async () => {
     if (!confirm("정말로 스터디를 탈퇴하시겠습니까?")) return;
     try {
@@ -279,26 +222,6 @@ const handleLeaveStudy = async () => {
     } catch (e) {
         console.error(e);
         alert(e.response?.data?.message || "탈퇴에 실패했습니다.");
-    }
-};
-
-const handleDeleteStudy = async () => {
-    if (userData.value.studyType === 'PERSONAL') {
-        alert("임시 스터디(Personal Study)는 직접 삭제할 수 없습니다.\n새로운 스터디를 생성하거나 다른 스터디에 가입하면 자동으로 정리됩니다.");
-        return;
-    }
-
-    if (!confirm("정말로 스터디를 해체하시겠습니까?\n\n이 작업은 되돌릴 수 없으며, 모든 미션과 기록이 삭제됩니다.")) return;
-    // 이중 확인 (안전을 위해)
-    if (!confirm("모든 스터디원이 탈퇴 처리되며, 스터디 정보가 영구적으로 삭제됩니다. 계속하시겠습니까?")) return;
-    
-    try {
-        await studyApi.deleteStudy(userData.value.studyId);
-        alert("스터디가 해체되었습니다.");
-        window.location.reload();
-    } catch (e) {
-        console.error(e);
-        alert(e.response?.data?.message || "해체에 실패했습니다.");
     }
 };
 
@@ -444,18 +367,11 @@ const showFaq = ref(false);
                             <!-- 스터디장 전용 -->
                             <template v-if="userData.isStudyLeader">
                                 <button 
-                                    @click="openDelegateModal(); showStudyMenu = false"
+                                    @click="goToStudyManage(); showStudyMenu = false"
                                     class="w-full text-left px-3 py-2.5 text-sm font-bold text-slate-600 hover:bg-slate-50 hover:text-slate-800 rounded-lg transition-colors flex items-center gap-2"
                                 >
-                                    <UserCheck :size="16" />
-                                    스터디장 위임
-                                </button>
-                                <button 
-                                    @click="openDeleteModal(); showStudyMenu = false"
-                                    class="w-full text-left px-3 py-2.5 text-sm font-bold text-rose-500 hover:bg-rose-50 rounded-lg transition-colors flex items-center gap-2"
-                                >
-                                    <Trash2 :size="16" />
-                                    스터디 해체
+                                    <Settings :size="16" />
+                                    스터디 설정 및 관리
                                 </button>
                             </template>
 
@@ -535,103 +451,7 @@ const showFaq = ref(false);
         <!-- ... (skipped for brevity) ... -->
         
         <!-- (At the end of template before styles) -->
-        <!-- Delegation Modal -->
         <Teleport to="body">
-            <div v-if="showDelegateModal" class="fixed inset-0 z-[9999] flex items-center justify-center p-4">
-                <div class="absolute inset-0 bg-slate-900/40 backdrop-blur-sm" @click="showDelegateModal = false"></div>
-                <!-- ... Content ... -->
-                <div class="relative bg-white rounded-3xl w-full max-w-md p-6 shadow-2xl animate-in fade-in zoom-in-95 duration-200">
-                    <h3 class="text-xl font-bold text-slate-800 mb-2">스터디장 위임</h3>
-                    <p class="text-sm text-slate-500 mb-6">새로운 스터디장을 선택해주세요.</p>
-                    
-                    <div v-if="loadingMembers" class="py-8 flex justify-center">
-                        <Loader2 class="animate-spin text-brand-500" :size="32"/>
-                    </div>
-                    
-                    <div v-else-if="memberList.length === 0" class="py-10 text-center text-slate-400 font-bold bg-slate-50 rounded-2xl">
-                        위임할 수 있는 다른 멤버가 없습니다.<br>
-                        <span class="text-xs font-normal mt-1 block">혼자라면 스터디 삭제만 가능합니다.</span>
-                    </div>
-
-                    <div v-else class="space-y-2 max-h-[300px] overflow-y-auto mb-6 custom-scrollbar">
-                        <label 
-                            v-for="member in memberList" 
-                            :key="member.id"
-                            class="flex items-center gap-3 p-3 rounded-xl border-2 cursor-pointer transition-all"
-                            :class="selectedMemberId === member.id ? 'border-brand-500 bg-brand-50' : 'border-slate-100 hover:border-slate-300'"
-                        >
-                            <input type="radio" :value="member.id" v-model="selectedMemberId" class="hidden">
-                            <img :src="member.avatarUrl || '/images/profiles/default-profile.png'" class="w-10 h-10 rounded-full bg-slate-200 object-cover" />
-                            <div class="flex-1">
-                                <div class="font-bold text-slate-700">{{ member.username }}</div>
-                                <div class="text-xs text-slate-400">Tier: {{ member.solvedacTier }}</div>
-                            </div>
-                            <div v-if="selectedMemberId === member.id" class="text-brand-600">
-                                <Crown :size="20" fill="currentColor" />
-                            </div>
-                        </label>
-                    </div>
-
-                    <div class="flex gap-3">
-                        <button 
-                            @click="showDelegateModal = false"
-                            class="flex-1 py-3.5 rounded-xl font-bold text-slate-500 hover:bg-slate-100 transition-colors"
-                        >
-                            취소
-                        </button>
-                        <button 
-                            @click="handleDelegate"
-                            :disabled="!selectedMemberId"
-                            class="flex-1 py-3.5 rounded-xl font-bold text-white bg-brand-500 hover:bg-brand-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-brand-500/30"
-                        >
-                            위임하기
-                        </button>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Delete Confirmation Modal -->
-            <div v-if="showDeleteConfirmModal" class="fixed inset-0 z-[9999] flex items-center justify-center p-4">
-                <div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" @click="showDeleteConfirmModal = false"></div>
-                
-                <div class="relative bg-white rounded-3xl w-full max-w-md p-6 shadow-2xl animate-in fade-in zoom-in-95 duration-200 border-2 border-slate-100">
-                    <div class="mb-4">
-                        <h3 class="text-xl font-black text-slate-800 mb-2">스터디 삭제</h3>
-                        <p class="text-sm text-slate-500 leading-relaxed">
-                            정말 <span class="text-slate-800 font-bold">'{{ studyName }}'</span> 스터디를 삭제하시겠습니까?<br>
-                            이 작업은 되돌릴 수 없으며, 모든 미션과 기록이 영구적으로 삭제됩니다.
-                        </p>
-                    </div>
-                    
-                    <div class="mb-6">
-                        <label class="block text-xs font-bold text-slate-400 mb-2 uppercase">스터디 이름을 입력하세요</label>
-                        <input 
-                            v-model="deleteInput"
-                            type="text"
-                            class="w-full bg-slate-50 border-2 border-slate-200 rounded-xl px-4 py-3 font-bold text-slate-700 focus:outline-none focus:border-rose-500 focus:bg-white transition-all placeholder:text-slate-300"
-                            :placeholder="studyName"
-                        />
-                    </div>
-
-                    <div class="flex gap-3">
-                        <button 
-                            @click="showDeleteConfirmModal = false"
-                            class="flex-1 py-3.5 rounded-xl font-bold text-slate-500 hover:bg-slate-100 transition-colors"
-                        >
-                            취소
-                        </button>
-                        <button 
-                            @click="handleConfirmDelete"
-                            :disabled="deleteInput !== studyName"
-                            class="flex-1 py-3.5 rounded-xl font-bold text-white bg-rose-500 hover:bg-rose-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-rose-500/30"
-                        >
-                            스터디 삭제
-                        </button>
-                    </div>
-                </div>
-            </div>
-
-
             <!-- Decoration Select Modal -->
             <div v-if="showDecorationModal" class="fixed inset-0 z-[9999] flex items-center justify-center p-4">
                 <div class="absolute inset-0 bg-slate-900/40 backdrop-blur-sm" @click="showDecorationModal = false"></div>

--- a/frontend/src/views/user/ProfileView.vue
+++ b/frontend/src/views/user/ProfileView.vue
@@ -6,12 +6,12 @@ import { studyApi } from '@/api/study';
 import { shopApi } from '@/api/shop';
 import { useAuth } from '@/composables/useAuth';
 import { onboardingApi } from '@/api/onboarding';
-import { Settings, LogOut, Github, Award, Users, Crown, RotateCcw, Loader2, HelpCircle, Zap as ZapIcon, Copy, Trash2, UserCheck, MoreVertical, AlertTriangle, ChevronDown, Palette, Check, Sparkles, X } from 'lucide-vue-next';
+import { Settings, LogOut, Github, Award, Users, Crown, RotateCcw, Loader2, HelpCircle, Zap as ZapIcon, Copy, MoreVertical, AlertTriangle, ChevronDown, Palette, Check, Sparkles, X } from 'lucide-vue-next';
 import BaseIconBadge from '@/components/common/BaseIconBadge.vue';
 import TroubleshootingModal from '@/components/common/TroubleshootingModal.vue';
 
 const router = useRouter();
-const { refresh, user, logout } = useAuth();
+const { logout } = useAuth();
 
 const goToStudyManage = () => {
     router.push('/study/manage');
@@ -365,7 +365,7 @@ const showFaq = ref(false);
                         <div v-if="showStudyMenu" class="absolute right-0 top-full mt-2 w-48 bg-white rounded-xl shadow-xl border border-slate-100 p-1.5 z-20 animate-in fade-in zoom-in-95 duration-200 origin-top-right flex flex-col gap-1">
                             
                             <!-- 스터디장 전용 -->
-                            <template v-if="userData.isStudyLeader">
+                            <template v-if="userData.isStudyLeader && userData.studyType !== 'PERSONAL'">
                                 <button 
                                     @click="goToStudyManage(); showStudyMenu = false"
                                     class="w-full text-left px-3 py-2.5 text-sm font-bold text-slate-600 hover:bg-slate-50 hover:text-slate-800 rounded-lg transition-colors flex items-center gap-2"


### PR DESCRIPTION
## 🚀 작업 배경

스터디장이 스터디의 기본 정보를 수정하고, 권한을 위임하거나 스터디를 해체할 수 있는 종합적인 관리 기능이 필요했습니다.

---

## 🛠️ 주요 변경 사항

1. 백엔드 (API)
- [x] 정보 수정 기능 추가
- [x] 각 관리 API 요청 시 생성자(Creator) 또는 관리자(ROLE_ADMIN) 여부를 확인하는 보안 로직 적용
- [x] 스터디 해체 시 관련 미션 및 기록들을 안전하게 처리하도록 서비스 로직 구현
- [x] StudyService 내의 모든 예외 상황을 Java 표준 예외에서 프로젝트 전용 BusinessException 및 ErrorCode 체계로 리팩토링
- [x] UserNotFoundException 등을 활용하여 사용자 조회 및 검증 로직을 타 모듈과 동일한 패턴으로 적용

2. 프론트엔드 (UI/UX)
- [x] 스터디 정보 수정, 해체 그리고 권한 위임을 할 수 있는 전용 관리 화면 구현
- [x] 권한 위임 및 해체 실수 방지를 위한 단계별 확인 모달 구현 및 디자인 최적화
- [x] 방장과 관리자에게만 노출되는 '스터디 관리' 메뉴 추가 및 접근 제어 로직 적용
- [x] 권한 위임 및 스터디 해체 성공 시, refresh() 함수를 호출하여 전역 사용자 정보를 즉시 갱신
- [x] ProfileView에서 스터디 타입이 PERSONAL인 경우 '스터디 관리' 버튼을 숨김 처리
- [x] 미사용 import(Trash2, UserCheck 등) 및 변수를 제거하여 컴포넌트 경량화.

---

## 🔗 관련 이슈

- Closes #115