### PR TITLE
hotfix:  ai 코드 분석 ondemand 적용

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,27 @@
+.gitattributes text eol=lf
+
+# Preserve existing wrapper behavior
 /gradlew text eol=lf
-*.bat text eol=crlf
-*.jar binary
 /backend/mvnw text eol=lf
+*.bat text eol=crlf
 *.cmd text eol=crlf
+*.jar binary
+
+# Source files stay LF across platforms
+*.java text eol=lf
+*.kt text eol=lf
+*.groovy text eol=lf
+*.xml text eol=lf
+*.sql text eol=lf
+*.properties text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.sh text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.vue text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.html text eol=lf
+*.json text eol=lf
+*.md text eol=lf

--- a/backend/src/main/java/com/ssafy/dash/ai/application/CodeReviewService.java
+++ b/backend/src/main/java/com/ssafy/dash/ai/application/CodeReviewService.java
@@ -2,20 +2,30 @@ package com.ssafy.dash.ai.application;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.dash.algorithm.domain.AlgorithmRecord;
+import com.ssafy.dash.algorithm.domain.AlgorithmRecordRepository;
 import com.ssafy.dash.ai.infrastructure.client.AiServerClient;
 import com.ssafy.dash.ai.infrastructure.client.dto.request.CodeReviewRequest;
 import com.ssafy.dash.ai.infrastructure.client.dto.response.CodeReviewResponse;
 import com.ssafy.dash.ai.infrastructure.client.dto.response.AiCounterExampleResponse;
 import com.ssafy.dash.ai.domain.CodeAnalysisResult;
 import com.ssafy.dash.ai.infrastructure.CodeAnalysisResultMapper;
+import com.ssafy.dash.user.domain.User;
+import com.ssafy.dash.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.annotation.Propagation;
 
 import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * 코드 리뷰 서비스
@@ -28,6 +38,9 @@ public class CodeReviewService {
     private final AiServerClient aiClient;
     private final CodeAnalysisResultMapper resultMapper;
     private final ObjectMapper objectMapper;
+    private final AlgorithmRecordRepository algorithmRecordRepository;
+    private final UserRepository userRepository;
+    private final ConcurrentMap<Long, Object> analyzeLocks = new ConcurrentHashMap<>();
 
     /**
      * 코드 분석 요청 및 결과 저장
@@ -36,6 +49,8 @@ public class CodeReviewService {
     public CodeAnalysisResult analyzeAndSave(Long algorithmRecordId, String code, String language,
             String problemNumber, String platform, String problemTitle) {
         log.info("Analyzing code for record: {}", algorithmRecordId);
+
+        Optional<CodeAnalysisResult> existing = resultMapper.findByAlgorithmRecordId(algorithmRecordId);
 
         // 1. AI 서버에 분석 요청
         CodeReviewRequest request = CodeReviewRequest.builder()
@@ -50,6 +65,7 @@ public class CodeReviewService {
 
         // 2. 응답을 엔티티로 변환
         CodeAnalysisResult result = convertToEntity(algorithmRecordId, response);
+        existing.ifPresent(previous -> copyCounterExampleFields(previous, result));
 
         // 3. 기존 분석 결과가 있으면 삭제 후 새로 저장
         resultMapper.deleteByAlgorithmRecordId(algorithmRecordId);
@@ -57,6 +73,43 @@ public class CodeReviewService {
 
         log.info("Code analysis saved for record: {}, score: {}", algorithmRecordId, result.getScore());
         return result;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public CodeAnalysisResult analyzeOnDemand(Long algorithmRecordId, Long requesterUserId, boolean force) {
+        if (algorithmRecordId == null) {
+            throw new IllegalArgumentException("algorithmRecordId는 필수입니다.");
+        }
+        if (requesterUserId == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+
+        AlgorithmRecord record = requireAuthorizedRecord(algorithmRecordId, requesterUserId);
+        Object lock = analyzeLocks.computeIfAbsent(algorithmRecordId, key -> new Object());
+
+        try {
+            synchronized (lock) {
+                Optional<CodeAnalysisResult> existing = resultMapper.findByAlgorithmRecordId(algorithmRecordId);
+                if (existing.isPresent() && !force && hasReviewContent(existing.get())) {
+                    return existing.get();
+                }
+
+                try {
+                    return analyzeAndSave(
+                            algorithmRecordId,
+                            record.getCode(),
+                            record.getLanguage(),
+                            record.getProblemNumber(),
+                            record.getPlatform(),
+                            record.getTitle());
+                } catch (DuplicateKeyException duplicate) {
+                    return resultMapper.findByAlgorithmRecordId(algorithmRecordId)
+                            .orElseThrow(() -> duplicate);
+                }
+            }
+        } finally {
+            analyzeLocks.remove(algorithmRecordId, lock);
+        }
     }
 
     /**
@@ -95,6 +148,11 @@ public class CodeReviewService {
      * 저장된 분석 결과 조회
      */
     public Optional<CodeAnalysisResult> getAnalysisResult(Long algorithmRecordId) {
+        return resultMapper.findByAlgorithmRecordId(algorithmRecordId);
+    }
+
+    public Optional<CodeAnalysisResult> getAnalysisResultAuthorized(Long algorithmRecordId, Long requesterUserId) {
+        requireAuthorizedRecord(algorithmRecordId, requesterUserId);
         return resultMapper.findByAlgorithmRecordId(algorithmRecordId);
     }
 
@@ -175,5 +233,55 @@ public class CodeReviewService {
             log.warn("Failed to convert to JSON: {}", e.getMessage());
             return null;
         }
+    }
+
+    private AlgorithmRecord requireAuthorizedRecord(Long algorithmRecordId, Long requesterUserId) {
+        AlgorithmRecord record = algorithmRecordRepository.findById(algorithmRecordId)
+                .orElseThrow(() -> new NoSuchElementException("해당 풀이 기록을 찾을 수 없습니다: " + algorithmRecordId));
+
+        if (Objects.equals(record.getUserId(), requesterUserId)) {
+            return record;
+        }
+
+        User requester = userRepository.findById(requesterUserId)
+                .orElseThrow(() -> new AccessDeniedException("로그인이 필요합니다."));
+
+        if ("ROLE_ADMIN".equals(requester.getRole())) {
+            return record;
+        }
+
+        if (requester.getStudyId() != null && Objects.equals(requester.getStudyId(), record.getStudyId())) {
+            return record;
+        }
+
+        throw new AccessDeniedException("이 기록의 AI 분석을 볼 권한이 없습니다.");
+    }
+
+    private boolean hasReviewContent(CodeAnalysisResult result) {
+        return result != null && (
+                hasText(result.getSummary()) ||
+                        hasText(result.getTimeComplexity()) ||
+                        hasText(result.getSpaceComplexity()) ||
+                        hasText(result.getComplexityExplanation()) ||
+                        hasText(result.getPatterns()) ||
+                        hasText(result.getAlgorithmIntuition()) ||
+                        hasText(result.getPitfalls()) ||
+                        hasText(result.getImprovements()) ||
+                        hasText(result.getKeyBlocks()) ||
+                        hasText(result.getFullResponse()) ||
+                        result.isRefactorProvided() ||
+                        hasText(result.getRefactorCode()) ||
+                        hasText(result.getRefactorExplanation()));
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private void copyCounterExampleFields(CodeAnalysisResult source, CodeAnalysisResult target) {
+        target.setCounterExampleInput(source.getCounterExampleInput());
+        target.setCounterExampleExpected(source.getCounterExampleExpected());
+        target.setCounterExamplePredicted(source.getCounterExamplePredicted());
+        target.setCounterExampleReason(source.getCounterExampleReason());
     }
 }

--- a/backend/src/main/java/com/ssafy/dash/ai/presentation/AiController.java
+++ b/backend/src/main/java/com/ssafy/dash/ai/presentation/AiController.java
@@ -17,13 +17,21 @@ import com.ssafy.dash.ai.presentation.dto.LearningDashboardResponse;
 import com.ssafy.dash.ai.presentation.dto.request.CodeReviewRequest;
 import com.ssafy.dash.ai.presentation.dto.request.HintChatRequestDto;
 import com.ssafy.dash.ai.presentation.dto.response.HintChatResponseDto;
+import com.ssafy.dash.oauth.presentation.security.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * AI API 컨트롤러
@@ -42,23 +50,49 @@ public class AiController {
 
         @Operation(summary = "코드 분석 요청", description = "알고리즘 풀이 코드를 AI로 분석합니다")
         @PostMapping("/review")
-        public ResponseEntity<CodeAnalysisResult> analyzeCode(@RequestBody CodeReviewRequest request) {
-                CodeAnalysisResult result = codeReviewService.analyzeAndSave(
-                                request.algorithmRecordId(),
-                                request.code(),
-                                request.language(),
-                                request.problemNumber(),
-                                request.platform(),
-                                request.problemTitle());
-                return ResponseEntity.ok(result);
+        public ResponseEntity<CodeAnalysisResult> analyzeCode(
+                        @Parameter(hidden = true) @AuthenticationPrincipal OAuth2User principal,
+                        @RequestBody CodeReviewRequest request) {
+                if (!(principal instanceof CustomOAuth2User customUser)) {
+                        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+                }
+                if (request.algorithmRecordId() == null) {
+                        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "algorithmRecordId는 필수입니다.");
+                }
+
+                try {
+                        CodeAnalysisResult result = codeReviewService.analyzeOnDemand(
+                                        request.algorithmRecordId(),
+                                        customUser.getUserId(),
+                                        Boolean.TRUE.equals(request.force()));
+                        return ResponseEntity.ok(result);
+                } catch (NoSuchElementException e) {
+                        throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+                } catch (AccessDeniedException e) {
+                        throw new ResponseStatusException(HttpStatus.FORBIDDEN, e.getMessage(), e);
+                } catch (IllegalArgumentException e) {
+                        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+                }
         }
 
         @Operation(summary = "분석 결과 조회", description = "저장된 분석 결과를 조회합니다")
         @GetMapping("/review/{algorithmRecordId}")
-        public ResponseEntity<CodeAnalysisResult> getAnalysisResult(@PathVariable Long algorithmRecordId) {
-                return codeReviewService.getAnalysisResult(algorithmRecordId)
-                                .map(ResponseEntity::ok)
-                                .orElse(ResponseEntity.notFound().build());
+        public ResponseEntity<CodeAnalysisResult> getAnalysisResult(
+                        @Parameter(hidden = true) @AuthenticationPrincipal OAuth2User principal,
+                        @PathVariable Long algorithmRecordId) {
+                if (!(principal instanceof CustomOAuth2User customUser)) {
+                        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+                }
+
+                try {
+                        return codeReviewService.getAnalysisResultAuthorized(algorithmRecordId, customUser.getUserId())
+                                        .map(ResponseEntity::ok)
+                                        .orElse(ResponseEntity.notFound().build());
+                } catch (NoSuchElementException e) {
+                        throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+                } catch (AccessDeniedException e) {
+                        throw new ResponseStatusException(HttpStatus.FORBIDDEN, e.getMessage(), e);
+                }
         }
 
         @Operation(summary = "AI 튜터 대화", description = "맞은 문제/틀린 문제 모두 지원하는 대화형 AI 튜터")

--- a/backend/src/main/java/com/ssafy/dash/ai/presentation/dto/request/CodeReviewRequest.java
+++ b/backend/src/main/java/com/ssafy/dash/ai/presentation/dto/request/CodeReviewRequest.java
@@ -6,5 +6,6 @@ public record CodeReviewRequest(
         String language,
         String problemNumber,
         String platform,
-        String problemTitle) {
+        String problemTitle,
+        Boolean force) {
 }

--- a/backend/src/main/java/com/ssafy/dash/github/application/GitHubPushEventWorker.java
+++ b/backend/src/main/java/com/ssafy/dash/github/application/GitHubPushEventWorker.java
@@ -22,7 +22,6 @@ import com.ssafy.dash.mockexam.application.MockExamService;
 import com.ssafy.dash.defense.application.DefenseService;
 import com.ssafy.dash.battle.application.BattleService;
 import com.ssafy.dash.acorn.application.AcornService;
-import com.ssafy.dash.ai.application.CodeReviewService;
 import com.ssafy.dash.study.application.StudyMissionService;
 import com.ssafy.dash.study.application.StudyService;
 import org.slf4j.Logger;
@@ -59,7 +58,6 @@ public class GitHubPushEventWorker {
     private final TransactionTemplate transactionTemplate;
     private final UserRepository userRepository;
     private final AcornService acornService;
-    private final CodeReviewService codeReviewService;
     private final StudyMissionService studyMissionService;
     private final MockExamService mockExamService;
     private final DefenseService defenseService;
@@ -76,7 +74,6 @@ public class GitHubPushEventWorker {
             PlatformTransactionManager transactionManager,
             UserRepository userRepository,
             AcornService acornService,
-            CodeReviewService codeReviewService,
             StudyMissionService studyMissionService,
             MockExamService mockExamService,
             DefenseService defenseService,
@@ -94,7 +91,6 @@ public class GitHubPushEventWorker {
         this.transactionTemplate = new TransactionTemplate(transactionManager);
         this.userRepository = userRepository;
         this.acornService = acornService;
-        this.codeReviewService = codeReviewService;
         this.studyMissionService = studyMissionService;
         this.mockExamService = mockExamService;
         this.defenseService = defenseService;
@@ -110,25 +106,7 @@ public class GitHubPushEventWorker {
                 return;
             }
             GitHubPushEvent event = optional.get();
-            // 트랜잭션 내에서 레코드 저장 후, 생성된 레코드 목록 반환
-            List<AlgorithmRecord> newRecords = transactionTemplate.execute(status -> processEvent(event));
-
-            // 트랜잭션 커밋 후 AI 분석 실행 (별도 트랜잭션)
-            if (newRecords != null) {
-                for (AlgorithmRecord record : newRecords) {
-                    try {
-                        codeReviewService.analyzeAndSave(
-                                record.getId(),
-                                record.getCode(),
-                                record.getLanguage(),
-                                record.getProblemNumber(),
-                                record.getPlatform(),
-                                record.getTitle());
-                    } catch (Exception e) {
-                        log.error("Auto-analysis failed via worker for record: {}", record.getId(), e);
-                    }
-                }
-            }
+            transactionTemplate.execute(status -> processEvent(event));
         }
     }
 

--- a/backend/src/main/java/com/ssafy/dash/study/application/StudyService.java
+++ b/backend/src/main/java/com/ssafy/dash/study/application/StudyService.java
@@ -12,6 +12,9 @@ import com.ssafy.dash.user.presentation.dto.response.UserResponse;
 import com.ssafy.dash.notification.application.NotificationService;
 import com.ssafy.dash.notification.domain.NotificationType;
 import com.ssafy.dash.study.domain.Study.StudyType;
+import com.ssafy.dash.common.exception.BusinessException;
+import com.ssafy.dash.common.exception.ErrorCode;
+import com.ssafy.dash.user.domain.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -101,7 +104,7 @@ public class StudyService {
     @Transactional
     public Study createStudy(Long userId, String name, String description, StudyVisibility visibility) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(userId));
 
         // 스터디 이동(Transition): 이미 다른 Group 스터디에 있다면, 탈퇴 또는 삭제 처리
         if (user.getStudyId() != null) {
@@ -151,7 +154,7 @@ public class StudyService {
     @Transactional
     public Study createPersonalStudy(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(userId));
 
         if (user.getStudyId() != null) {
             return studyRepository.findById(user.getStudyId()).orElse(null);
@@ -172,13 +175,13 @@ public class StudyService {
     @Transactional
     public void applyForStudy(Long userId, Long studyId, String message) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(userId));
 
         // 스터디 이동 로직은 승인 시점에 처리됩니다. (applyForStudy에서는 체크하지 않음)
 
         // 스터디 존재 여부 확인
         if (studyRepository.findById(studyId).isEmpty()) {
-            throw new IllegalArgumentException("Study not found");
+            throw new BusinessException(ErrorCode.RESOURCE_NOT_FOUND);
         }
 
         // 이미 가입 신청했는지 확인
@@ -206,10 +209,10 @@ public class StudyService {
     @Transactional(readOnly = true)
     public List<StudyApplication> getPendingApplications(Long userId, Long studyId) {
         Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (!Objects.equals(study.getCreatorId(), userId)) {
-            throw new SecurityException("Only creator can view applications");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         return studyRepository.findPendingApplicationsByStudyId(studyId);
@@ -223,10 +226,10 @@ public class StudyService {
     @Transactional
     public void cancelApplication(Long userId, Long applicationId) {
         StudyApplication application = studyRepository.findApplicationById(applicationId)
-                .orElseThrow(() -> new IllegalArgumentException("Application not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (!Objects.equals(application.getUserId(), userId)) {
-            throw new SecurityException("Cannot cancel other's application");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         application.reject();
@@ -236,18 +239,18 @@ public class StudyService {
     @Transactional
     public void approveApplication(Long adminId, Long applicationId) {
         StudyApplication application = studyRepository.findApplicationById(applicationId)
-                .orElseThrow(() -> new IllegalArgumentException("Application not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         Study study = studyRepository.findById(application.getStudyId())
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (!Objects.equals(study.getCreatorId(), adminId)) {
-            throw new SecurityException("Only creator can approve applications");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         // 유저를 스터디에 추가
         User user = userRepository.findById(application.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(application.getUserId()));
 
         // 탈퇴한 유저인지 확인
         if (user.isDeleted()) {
@@ -314,13 +317,13 @@ public class StudyService {
     @Transactional
     public void rejectApplication(Long leaderId, Long applicationId, String reason) {
         StudyApplication application = studyRepository.findApplicationById(applicationId)
-                .orElseThrow(() -> new IllegalArgumentException("Application not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         Study study = studyRepository.findById(application.getStudyId())
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (!Objects.equals(study.getCreatorId(), leaderId)) {
-            throw new SecurityException("Only creator can reject applications");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         // DB에서 삭제하여 재가입 가능하도록 함
@@ -342,7 +345,7 @@ public class StudyService {
     @Transactional
     public void leaveStudy(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(userId));
 
         if (user.getStudyId() == null) {
             throw new IllegalStateException("User is not in a study");
@@ -350,7 +353,7 @@ public class StudyService {
 
         Long oldStudyId = user.getStudyId();
         Study study = studyRepository.findById(oldStudyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (Objects.equals(study.getCreatorId(), userId)) {
             // 정책: 스터디장은 탈퇴할 수 없음. 스터디를 해체하거나 권한을 위임해야 함. (아직 구현되지 않음)
@@ -385,10 +388,14 @@ public class StudyService {
     @Transactional
     public void updateStudy(Long userId, Long studyId, String name, String description) {
         Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
-        if (!java.util.Objects.equals(study.getCreatorId(), userId)) {
-            throw new SecurityException("Only creator can update the study");
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        boolean isAdmin = "ROLE_ADMIN".equals(user.getRole());
+        if (!java.util.Objects.equals(study.getCreatorId(), userId) && !isAdmin) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         if (name != null && !name.isBlank()) {
@@ -404,15 +411,15 @@ public class StudyService {
     @Transactional
     public void deleteStudy(Long userId, Long studyId) {
         Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new UserNotFoundException(userId));
 
         // 스터디장 또는 관리자만 삭제 가능
         boolean isAdmin = "ROLE_ADMIN".equals(user.getRole());
         if (!Objects.equals(study.getCreatorId(), userId) && !isAdmin) {
-            throw new SecurityException("Only creator or admin can delete the study");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         // 1. 모든 멤버를 각자의 Personal 스터디로 쫓아냄
@@ -439,7 +446,7 @@ public class StudyService {
     @Transactional(readOnly = true)
     public List<UserResponse> getStudyMembers(Long studyId) {
         Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         return userRepository.findByStudyId(studyId).stream()
                 .map(user -> UserResult.from(user, null, study))
@@ -458,17 +465,21 @@ public class StudyService {
     @Transactional
     public void delegateLeader(Long currentLeaderId, Long studyId, Long newLeaderId) {
         Study study = studyRepository.findById(studyId)
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
-        if (!Objects.equals(study.getCreatorId(), currentLeaderId)) {
-            throw new SecurityException("Only creator can delegate the leader role");
+        User user = userRepository.findById(currentLeaderId)
+                .orElseThrow(() -> new UserNotFoundException(currentLeaderId));
+
+        boolean isAdmin = "ROLE_ADMIN".equals(user.getRole());
+        if (!Objects.equals(study.getCreatorId(), currentLeaderId) && !isAdmin) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         User newLeader = userRepository.findById(newLeaderId)
-                .orElseThrow(() -> new IllegalArgumentException("New leader not found"));
+                .orElseThrow(() -> new UserNotFoundException(newLeaderId));
 
         if (!Objects.equals(newLeader.getStudyId(), studyId)) {
-            throw new IllegalArgumentException("New leader must be a member of the study");
+            throw new BusinessException(ErrorCode.VALIDATION_FAILED);
         }
 
         study.setCreatorId(newLeaderId);
@@ -485,13 +496,13 @@ public class StudyService {
     @Transactional(readOnly = true)
     public StudyApplication getApplicationDetail(Long userId, Long applicationId) {
         StudyApplication app = studyRepository.findApplicationById(applicationId)
-                .orElseThrow(() -> new IllegalArgumentException("Application not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         Study study = studyRepository.findById(app.getStudyId())
-                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (!Objects.equals(study.getCreatorId(), userId)) {
-            throw new SecurityException("Only creator can view application details");
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         return app;

--- a/backend/src/main/java/com/ssafy/dash/study/application/StudyService.java
+++ b/backend/src/main/java/com/ssafy/dash/study/application/StudyService.java
@@ -383,6 +383,25 @@ public class StudyService {
     }
 
     @Transactional
+    public void updateStudy(Long userId, Long studyId, String name, String description) {
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new IllegalArgumentException("Study not found"));
+
+        if (!java.util.Objects.equals(study.getCreatorId(), userId)) {
+            throw new SecurityException("Only creator can update the study");
+        }
+
+        if (name != null && !name.isBlank()) {
+            study.setName(name);
+        }
+        if (description != null) {
+            study.setDescription(description);
+        }
+
+        studyRepository.update(study);
+    }
+
+    @Transactional
     public void deleteStudy(Long userId, Long studyId) {
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new IllegalArgumentException("Study not found"));

--- a/backend/src/main/java/com/ssafy/dash/study/presentation/StudyController.java
+++ b/backend/src/main/java/com/ssafy/dash/study/presentation/StudyController.java
@@ -6,6 +6,7 @@ import com.ssafy.dash.study.application.StudyMissionService;
 import com.ssafy.dash.study.application.StudyService;
 import com.ssafy.dash.study.domain.Study;
 import com.ssafy.dash.study.presentation.dto.CreateStudyRequest;
+import com.ssafy.dash.study.presentation.dto.UpdateStudyRequest;
 import com.ssafy.dash.study.presentation.dto.request.ApplyStudyRequest;
 import com.ssafy.dash.study.presentation.dto.request.CreateMissionRequest;
 import com.ssafy.dash.study.presentation.dto.request.AddMissionProblemsRequest;
@@ -97,6 +98,19 @@ public class StudyController {
         if (principal instanceof CustomOAuth2User customUser) {
             Study study = studyService.createPersonalStudy(customUser.getUserId());
             return ResponseEntity.ok(CreateStudyResponse.from(study));
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @Operation(summary = "스터디 정보 수정", description = "스터디의 이름이나 소개를 수정합니다.")
+    @PatchMapping("/{studyId}")
+    public ResponseEntity<Void> updateStudy(
+            @Parameter(hidden = true) @AuthenticationPrincipal OAuth2User principal,
+            @PathVariable Long studyId,
+            @RequestBody UpdateStudyRequest request) {
+        if (principal instanceof CustomOAuth2User customUser) {
+            studyService.updateStudy(customUser.getUserId(), studyId, request.getName(), request.getDescription());
+            return ResponseEntity.ok().build();
         }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }

--- a/backend/src/main/java/com/ssafy/dash/study/presentation/dto/UpdateStudyRequest.java
+++ b/backend/src/main/java/com/ssafy/dash/study/presentation/dto/UpdateStudyRequest.java
@@ -1,0 +1,13 @@
+package com.ssafy.dash.study.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateStudyRequest {
+    private String name;
+    private String description;
+}

--- a/backend/src/main/java/com/ssafy/dash/study/presentation/dto/response/StudyListResponse.java
+++ b/backend/src/main/java/com/ssafy/dash/study/presentation/dto/response/StudyListResponse.java
@@ -22,7 +22,8 @@ public record StudyListResponse(
         LocalDate streakUpdatedAt, // streak 유효성 판단용
         Double averageSubmissionRate,
         List<MemberPreview> memberPreviews, // 멤버 미리보기 (프론트에서 표시 개수 조절)
-        String description) {
+        String description,
+        Long creatorId) {
 
     public static StudyListResponse from(Study study, List<User> members) {
         List<MemberPreview> previews = members != null
@@ -44,7 +45,8 @@ public record StudyListResponse(
                 study.getStreakUpdatedAt(),
                 study.getAverageSubmissionRate() != null ? study.getAverageSubmissionRate() : 0.0,
                 previews,
-                study.getDescription());
+                study.getDescription(),
+                study.getCreatorId());
     }
 
     private static String getTierBadge(Double tier) {

--- a/frontend/src/api/study.js
+++ b/frontend/src/api/study.js
@@ -25,6 +25,10 @@ export const studyApi = {
     get(studyId) {
         return http.get(`/studies/${studyId}`);
     },
+    // Update study details
+    update(studyId, data) {
+        return http.patch(`/studies/${studyId}`, data);
+    },
     // Get acorn logs
     getAcornLogs(studyId) {
         return http.get(`/studies/${studyId}/acorns`);

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -127,6 +127,12 @@ const routes = [
     meta: { requiresAuth: true }
   },
   {
+    path: "/study/manage",
+    name: "StudyManage",
+    component: () => import("../views/study/StudyManageView.vue"),
+    meta: { requiresAuth: true }
+  },
+  {
     path: "/admin/study/:id/dashboard",
     name: "AdminStudyDashboard",
     component: Dashboard,

--- a/frontend/src/views/dashboard/AnalysisSidebar.vue
+++ b/frontend/src/views/dashboard/AnalysisSidebar.vue
@@ -4,8 +4,8 @@
       <div class="w-16 h-16 bg-slate-50 rounded-full flex items-center justify-center mb-4">
         <Activity class="w-8 h-8 opacity-20" />
       </div>
-      <p class="text-sm font-bold text-slate-500 mb-1">분석할 기록을 선택해주세요</p>
-      <p class="text-xs">타임라인에서 항목을 클릭하면<br/>상세 분석이 여기에 표시됩니다.</p>
+      <p class="text-sm font-bold text-slate-500 mb-1">분석할 기록을 선택해 주세요</p>
+      <p class="text-xs">오른쪽 카드에서 항목을 클릭하면<br/>상세 분석을 바로 확인할 수 있습니다.</p>
     </div>
 
     <template v-else>
@@ -28,16 +28,26 @@
             
             <!-- 1. OVERVIEW TAB -->
             <div v-if="activeTab === 'overview'" class="p-5 flex flex-col h-full">
-                <div v-if="!hasAnyAnalysis" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full animate-pulse">
+                <div v-if="analysisStatus === 'loading'" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full animate-pulse">
                     <Loader2 class="w-8 h-8 mb-4 animate-spin text-brand-500" />
-                    <p class="text-sm font-bold text-slate-600 mb-1">AI가 코드를 분석하고 있습니다</p>
-                    <p class="text-xs">잠시만 기다려주세요...</p>
+                    <p class="text-sm font-bold text-slate-600 mb-1">AI 분석을 생성하고 있습니다</p>
+                    <p class="text-xs">잠시만 기다려 주세요...</p>
+                </div>
+                <div v-else-if="analysisStatus === 'error'" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full">
+                    <p class="text-sm font-bold text-rose-600 mb-2">AI 분석 생성에 실패했습니다</p>
+                    <p class="text-xs text-slate-500 mb-4">{{ analysisError || '잠시 후 다시 시도해 주세요.' }}</p>
+                    <button @click="retryAnalysis" class="px-4 py-2 bg-brand-600 hover:bg-brand-500 text-white rounded-lg text-xs font-bold">
+                        다시 시도
+                    </button>
+                </div>
+                <div v-else-if="!hasAnyAnalysis" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full">
+                    <p class="text-sm font-bold text-slate-600 mb-1">표시할 AI 분석이 아직 없습니다</p>
                 </div>
                 <div v-else class="space-y-6 flex-1">
                     <!-- Structure: Variables & Functions -->
                     <div v-if="parsedVariables.length > 0 || parsedFunctions.length > 0" class="bg-white p-4 rounded-xl border border-slate-200 shadow-sm">
                         <h4 class="text-xs font-bold text-slate-800 mb-3 flex items-center gap-2">
-                            <LayoutList :size="14" class="text-blue-500"/> 변수 및 함수
+                            <LayoutList :size="14" class="text-blue-500"/> 변수와 함수
                         </h4>
                         
                         <!-- Variables -->
@@ -143,10 +153,20 @@
 
             <!-- 2. ANALYSIS TAB -->
             <div v-if="activeTab === 'analysis'" class="p-5 flex flex-col h-full">
-                <div v-if="!hasAnyAnalysis" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full animate-pulse">
+                <div v-if="analysisStatus === 'loading'" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full animate-pulse">
                     <Loader2 class="w-8 h-8 mb-4 animate-spin text-brand-500" />
-                    <p class="text-sm font-bold text-slate-600 mb-1">AI가 코드를 분석하고 있습니다</p>
-                    <p class="text-xs">잠시만 기다려주세요...</p>
+                    <p class="text-sm font-bold text-slate-600 mb-1">AI 분석을 생성하고 있습니다</p>
+                    <p class="text-xs">잠시만 기다려 주세요...</p>
+                </div>
+                <div v-else-if="analysisStatus === 'error'" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full">
+                    <p class="text-sm font-bold text-rose-600 mb-2">AI 분석 생성에 실패했습니다</p>
+                    <p class="text-xs text-slate-500 mb-4">{{ analysisError || '잠시 후 다시 시도해 주세요.' }}</p>
+                    <button @click="retryAnalysis" class="px-4 py-2 bg-brand-600 hover:bg-brand-500 text-white rounded-lg text-xs font-bold">
+                        다시 시도
+                    </button>
+                </div>
+                <div v-else-if="!hasAnyAnalysis" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full">
+                    <p class="text-sm font-bold text-slate-600 mb-1">표시할 AI 분석이 아직 없습니다</p>
                 </div>
                 <!-- Complexity Cards -->
                 <div v-else class="space-y-6">
@@ -168,7 +188,7 @@
                             @click="showComplexityExplanation = !showComplexityExplanation"
                             class="text-xs text-brand-500 hover:text-brand-600 font-bold flex items-center gap-1 mx-auto transition-colors"
                         >
-                            <HelpCircle :size="12" /> 왜 이런 복잡도를 가지나요? <ChevronDown :size="12" class="transition-transform duration-300" :class="{ 'rotate-180': showComplexityExplanation }"/>
+                            <HelpCircle :size="12" /> 왜 이런 복잡도를 가지는지 보기 <ChevronDown :size="12" class="transition-transform duration-300" :class="{ 'rotate-180': showComplexityExplanation }"/>
                         </button>
                         <div v-if="showComplexityExplanation" class="mt-3 bg-slate-50 p-3 rounded-lg border border-slate-200 animate-slide-down">
                             <div class="text-xs text-slate-600 leading-relaxed whitespace-pre-line" v-html="renderMarkdown(record.complexityExplanation)"></div>
@@ -192,7 +212,7 @@
                 <!-- Refactoring -->
                 <div v-if="record.refactorProvided" class="space-y-3">
                     <h4 class="text-xs font-bold text-emerald-600 flex items-center gap-2">
-                        <Wand2 :size="14"/> 리팩토링 제안
+                        <Wand2 :size="14"/> 리팩터링 제안
                     </h4>
                     <div class="bg-emerald-50 p-3 rounded-lg border border-emerald-100">
                         <div class="text-xs text-slate-700 leading-relaxed mb-3" v-html="renderMarkdown(record.refactorExplanation)"></div>
@@ -213,16 +233,31 @@
 
             <!-- 3. COUNTER TAB -->
             <div v-if="activeTab === 'counter'" class="p-5 flex flex-col h-full">
-                <div v-if="isPassed" class="flex flex-col items-center justify-center flex-1 text-center p-6 text-slate-400 bg-slate-100 rounded-xl border border-dashed border-slate-300">
+                <div v-if="analysisStatus === 'loading'" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full animate-pulse">
+                    <Loader2 class="w-8 h-8 mb-4 animate-spin text-brand-500" />
+                    <p class="text-sm font-bold text-slate-600 mb-1">AI 분석을 생성하고 있습니다</p>
+                    <p class="text-xs">분석이 완료되면 반례 생성이 가능합니다.</p>
+                </div>
+                <div v-else-if="analysisStatus === 'error'" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full">
+                    <p class="text-sm font-bold text-rose-600 mb-2">AI 분석 생성에 실패했습니다</p>
+                    <p class="text-xs text-slate-500 mb-4">{{ analysisError || '잠시 후 다시 시도해 주세요.' }}</p>
+                    <button @click="retryAnalysis" class="px-4 py-2 bg-brand-600 hover:bg-brand-500 text-white rounded-lg text-xs font-bold">
+                        다시 시도
+                    </button>
+                </div>
+                <div v-else-if="!hasAnyAnalysis" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full">
+                    <p class="text-sm font-bold text-slate-600 mb-1">반례 생성을 위한 분석 데이터가 아직 없습니다</p>
+                </div>
+                <div v-else-if="isPassed" class="flex flex-col items-center justify-center flex-1 text-center p-6 text-slate-400 bg-slate-100 rounded-xl border border-dashed border-slate-300">
                     <template v-if="record.tag === 'MOCK_EXAM' || record.tag === 'TEST'">
                         <Trophy :size="32" class="mb-2 text-amber-500 opacity-80"/>
                         <p class="text-xs font-bold text-slate-600 mb-1">시험 통과!</p>
-                        <p class="text-[10px]">문제 해결을 축하합니다. 훌륭한 성과입니다!</p>
+                        <p class="text-[10px]">문제 해결을 축하합니다. 좋은 결과입니다.</p>
                     </template>
                     <template v-else>
                         <CheckCircle2 :size="32" class="mb-2 text-emerald-500 opacity-50"/>
-                        <p class="text-xs font-bold text-slate-600 mb-1">이미 해결된 문제입니다!</p>
-                        <p class="text-[10px]">정답 코드는 반례 생성 기능을 사용할 수 없습니다.</p>
+                        <p class="text-xs font-bold text-slate-600 mb-1">이미 해결한 문제입니다</p>
+                        <p class="text-[10px]">정답 코드에는 반례 생성 기능을 사용할 필요가 없습니다.</p>
                     </template>
                 </div>
                 <div v-else class="flex flex-col h-full">
@@ -230,7 +265,7 @@
                         <button @click="findCounterExample" class="px-5 py-2.5 bg-rose-500 hover:brightness-90 text-white rounded-lg font-bold text-xs shadow-lg shadow-rose-500/30 transition-all flex items-center gap-2">
                             <Bug :size="14"/> 반례 생성하기
                         </button>
-                        <p class="text-[10px] text-slate-400 mt-3">AI가 코드를 분석하여 실패 원인을 찾아냅니다.</p>
+                        <p class="text-[10px] text-slate-400 mt-3">AI가 코드를 분석해 실패 원인을 찾습니다.</p>
                     </div>
                     
                     <div v-if="loadingAi" class="flex-1 flex flex-col items-center justify-center text-slate-400">
@@ -277,15 +312,25 @@
 
             <!-- 4. TUTOR TAB -->
             <div v-if="activeTab === 'tutor'" class="flex flex-col h-full relative">
-                <div v-if="!hasAnyAnalysis" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full animate-pulse">
+                <div v-if="analysisStatus === 'loading'" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full animate-pulse">
                     <Loader2 class="w-8 h-8 mb-4 animate-spin text-brand-500" />
-                    <p class="text-sm font-bold text-slate-600 mb-1">AI가 코드를 분석하고 있습니다</p>
-                    <p class="text-xs">분석이 완료되면 튜터 기능을 사용할 수 있습니다.</p>
+                    <p class="text-sm font-bold text-slate-600 mb-1">AI 분석을 생성하고 있습니다</p>
+                    <p class="text-xs">완료되면 튜터 기능을 사용할 수 있습니다.</p>
+                </div>
+                <div v-else-if="analysisStatus === 'error'" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full">
+                    <p class="text-sm font-bold text-rose-600 mb-2">AI 분석 생성에 실패했습니다</p>
+                    <p class="text-xs text-slate-500 mb-4">{{ analysisError || '잠시 후 다시 시도해 주세요.' }}</p>
+                    <button @click="retryAnalysis" class="px-4 py-2 bg-brand-600 hover:bg-brand-500 text-white rounded-lg text-xs font-bold">
+                        다시 시도
+                    </button>
+                </div>
+                <div v-else-if="!hasAnyAnalysis" class="flex-1 flex flex-col items-center justify-center text-slate-400 p-8 text-center h-full">
+                    <p class="text-sm font-bold text-slate-600 mb-1">튜터를 위한 분석 데이터가 아직 없습니다</p>
                 </div>
                 <div v-else class="flex-1 overflow-y-auto p-4 space-y-4 custom-scrollbar" ref="chatContainer">
                     <div v-if="tutorMessages.length === 0" class="flex flex-col items-center justify-center h-full text-slate-400 text-center opacity-70">
                         <Bot :size="32" class="mb-2"/>
-                        <p class="text-xs mb-4">코드에 대해 궁금한 점을 물어보세요!</p>
+                        <p class="text-xs mb-4">코드에 대한 궁금한 점을 물어보세요</p>
                         <div class="flex flex-wrap justify-center gap-2 max-w-[80%]">
                             <button @click="sendSuggestion('코드의 핵심 로직을 설명해줘')" class="px-3 py-1.5 bg-white border border-slate-200 rounded-full text-[10px] hover:border-brand-400 hover:text-brand-600 transition-colors shadow-sm">
                                 <Brain :size="12" class="inline mr-1"/> 핵심 로직 설명
@@ -294,9 +339,9 @@
                                 <Zap :size="12" class="inline mr-1"/> 시간 복잡도 분석
                             </button>
                             <button @click="sendSuggestion('이 코드를 어떻게 개선할 수 있어?')" class="px-3 py-1.5 bg-white border border-slate-200 rounded-full text-[10px] hover:border-brand-400 hover:text-brand-600 transition-colors shadow-sm">
-                                <Sparkles :size="12" class="inline mr-1"/> 코드 개선점
+                                <Sparkles :size="12" class="inline mr-1"/> 코드 개선 질문
                             </button>
-                        </div>
+                    </div>
                     </div>
                     <div v-for="(msg, idx) in tutorMessages" :key="idx" 
                         class="flex gap-3" :class="msg.role === 'user' ? 'flex-row-reverse' : ''">
@@ -311,7 +356,7 @@
                             <div v-else-if="msg.isLoading">
                                 <div class="flex items-center gap-2 text-slate-400">
                                     <Loader2 :size="14" class="animate-spin text-brand-500"/>
-                                    <span class="text-[10px] font-bold animate-pulse">답변 생성 중...</span>
+                                    <span class="text-[10px] font-bold animate-pulse">응답 생성 중...</span>
                                 </div>
                             </div>
                             <div v-else>
@@ -373,7 +418,7 @@ const props = defineProps({
   record: { type: Object, default: null }
 });
 
-const emit = defineEmits(['scroll-to-line', 'acorn-used']);
+const emit = defineEmits(['scroll-to-line', 'acorn-used', 'analysis-loaded']);
 
 const { user } = useAuth();
 
@@ -396,16 +441,30 @@ const tutorMessages = ref([]);
 const loadingTutorResponse = ref(false);
 const chatContainer = ref(null);
 const tutorInputRef = ref(null);
+const mergedRecord = ref(null);
+const analysisStatus = ref('idle'); // idle | loading | ready | error
+const analysisError = ref('');
+const currentAnalysisRequestId = ref(0);
+const record = computed(() => mergedRecord.value);
 
 // Reset when record changes
-watch(() => props.record, (newRecord) => {
-    if (newRecord) {
+watch(
+    () => props.record,
+    async (newRecord) => {
         activeTab.value = 'overview';
         tutorMessages.value = [];
         showTrace.value = false;
         showComplexityExplanation.value = false;
-        
-        // Initialize AI Data if exists
+        analysisError.value = '';
+
+        if (!newRecord) {
+            mergedRecord.value = null;
+            aiData.value = null;
+            analysisStatus.value = 'idle';
+            return;
+        }
+
+        mergedRecord.value = { ...newRecord };
         if (newRecord.counterExampleInput) {
             aiData.value = {
                 input: newRecord.counterExampleInput,
@@ -416,22 +475,118 @@ watch(() => props.record, (newRecord) => {
         } else {
             aiData.value = null;
         }
-    } else {
-        aiData.value = null;
-    }
+
+        if (hasExistingAnalysis(newRecord)) {
+            analysisStatus.value = 'ready';
+            return;
+        }
+
+        await ensureAnalysisLoaded();
+    },
+    { immediate: true }
+);
+
+const hasExistingAnalysis = (recordLike) => {
+    if (!recordLike) return false;
+    return Boolean(
+        recordLike.summary ||
+        recordLike.timeComplexity ||
+        recordLike.spaceComplexity ||
+        recordLike.fullResponse ||
+        recordLike.pitfalls ||
+        recordLike.algorithmIntuition ||
+        recordLike.keyBlocks ||
+        recordLike.refactorProvided
+    );
+};
+
+const mapAnalysisToRecord = (analysis) => ({
+    score: analysis.score ?? null,
+    timeComplexity: analysis.timeComplexity ?? null,
+    spaceComplexity: analysis.spaceComplexity ?? null,
+    complexityExplanation: analysis.complexityExplanation ?? null,
+    patterns: analysis.patterns ?? null,
+    algorithmIntuition: analysis.algorithmIntuition ?? null,
+    pitfalls: analysis.pitfalls ?? null,
+    keyBlocks: analysis.keyBlocks ?? null,
+    refactorProvided: analysis.refactorProvided ?? false,
+    refactorCode: analysis.refactorCode ?? null,
+    refactorExplanation: analysis.refactorExplanation ?? null,
+    fullResponse: analysis.fullResponse ?? null
 });
+
+const applyAnalysisToRecord = (analysis) => {
+    const nextRecord = { ...record.value, ...mapAnalysisToRecord(analysis || {}) };
+    mergedRecord.value = nextRecord;
+    emit('analysis-loaded', nextRecord);
+    return nextRecord;
+};
+
+const ensureAnalysisLoaded = async ({ force = false } = {}) => {
+    if (!record.value?.id) return;
+    const requestId = ++currentAnalysisRequestId.value;
+    analysisStatus.value = 'loading';
+    analysisError.value = '';
+
+    try {
+        let analysis = null;
+
+        if (!force) {
+            const existing = await aiApi.getAnalysisResult(record.value.id);
+            const existingData = existing?.data ?? null;
+            analysis = hasExistingAnalysis(existingData) ? existingData : null;
+        }
+
+        if (!analysis) {
+            const created = await aiApi.analyzeCode({
+                algorithmRecordId: record.value.id,
+                force
+            });
+            analysis = created?.data ?? null;
+        }
+
+        if (requestId !== currentAnalysisRequestId.value) return;
+        applyAnalysisToRecord(analysis);
+        analysisStatus.value = 'ready';
+    } catch (error) {
+        if (requestId !== currentAnalysisRequestId.value) return;
+
+        if (error?.response?.status === 404 && !force) {
+            try {
+                const created = await aiApi.analyzeCode({
+                    algorithmRecordId: record.value.id
+                });
+                if (requestId !== currentAnalysisRequestId.value) return;
+                applyAnalysisToRecord(created?.data || {});
+                analysisStatus.value = 'ready';
+                return;
+            } catch (createError) {
+                analysisError.value = createError?.response?.data?.message || '분석 생성 요청에 실패했습니다.';
+                analysisStatus.value = 'error';
+                return;
+            }
+        }
+
+        analysisError.value = error?.response?.data?.message || '분석 조회에 실패했습니다.';
+        analysisStatus.value = 'error';
+    }
+};
+
+const retryAnalysis = async () => {
+    await ensureAnalysisLoaded({ force: true });
+};
 
 // Computed Properties (Parsing)
 const parsedFullResponse = computed(() => {
-    if (!props.record?.fullResponse) return null;
-    try { return JSON.parse(props.record.fullResponse); } catch { return null; }
+    if (!record.value?.fullResponse) return null;
+    try { return JSON.parse(record.value.fullResponse); } catch { return null; }
 });
 
 const fetchTutorHistory = async () => {
-    if (!props.record?.id || !user.value?.id) return;
+    if (!record.value?.id || !user.value?.id) return;
     
     try {
-        const res = await aiApi.getTutorHistory(props.record.id, user.value.id);
+        const res = await aiApi.getTutorHistory(record.value.id, user.value.id);
         if (Array.isArray(res.data)) {
             tutorMessages.value = res.data.map(m => ({
                 role: m.role,
@@ -460,34 +615,47 @@ const parsedVariables = computed(() => parsedStructure.value.filter(item => !ite
 const parsedFunctions = computed(() => parsedStructure.value.filter(item => item.type === 'function' || item.type === 'class'));
 
 const parsedKeyBlocks = computed(() => {
-    if (!props.record?.keyBlocks) return [];
-    try { return Array.isArray(JSON.parse(props.record.keyBlocks)) ? JSON.parse(props.record.keyBlocks) : []; } catch { return []; }
+    if (!record.value?.keyBlocks) return [];
+    try { return Array.isArray(JSON.parse(record.value.keyBlocks)) ? JSON.parse(record.value.keyBlocks) : []; } catch { return []; }
 });
 
 const parsedSummary = computed(() => parsedFullResponse.value?.summary || null);
 const parsedTraceExample = computed(() => parsedFullResponse.value?.traceExample || null);
-const parsedIntuition = computed(() => parsedFullResponse.value?.algorithm?.intuition || props.record?.algorithmIntuition || null);
+const parsedIntuition = computed(() => parsedFullResponse.value?.algorithm?.intuition || record.value?.algorithmIntuition || null);
 
 const parsedPitfalls = computed(() => {
-    if (!parsedFullResponse.value || !parsedFullResponse.value.pitfalls) return [];
-    return Array.isArray(parsedFullResponse.value.pitfalls) ? parsedFullResponse.value.pitfalls : [];
+    const fullResponsePitfalls = parsedFullResponse.value?.pitfalls;
+    if (Array.isArray(fullResponsePitfalls)) {
+        return fullResponsePitfalls;
+    }
+
+    if (record.value?.pitfalls) {
+        try {
+            const parsed = JSON.parse(record.value.pitfalls);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch {
+            return [];
+        }
+    }
+
+    return [];
 });
 
 const hasAnyAnalysis = computed(() => {
-    return props.record?.timeComplexity || 
-           props.record?.spaceComplexity || 
+    return record.value?.timeComplexity || 
+           record.value?.spaceComplexity || 
            parsedPitfalls.value.length > 0 || 
-           props.record?.refactorProvided || 
+           record.value?.refactorProvided || 
            parsedVariables.value.length > 0 || 
            parsedSummary.value || 
            parsedIntuition.value;
 });
 
 const isPassed = computed(() => {
-    if (!props.record) return false;
-    // runtimeMs가 null이거나 -1이면 실패로 처리
-    const runtime = props.record.runtimeMs;
-    return props.record.result === 'SUCCESS' || props.record.result === 'PASSED' || (runtime !== null && runtime !== undefined && runtime !== -1);
+    if (!record.value) return false;
+    // runtimeMs媛 null?닿굅??-1?대㈃ ?ㅽ뙣濡?泥섎━
+    const runtime = record.value.runtimeMs;
+    return record.value.result === 'SUCCESS' || record.value.result === 'PASSED' || (runtime !== null && runtime !== undefined && runtime !== -1);
 });
 
 // ACTIONS
@@ -498,8 +666,8 @@ const emitScrollToLine = (start, end) => {
 };
 
 const viewCodeLine = (name) => {
-    if (!name || !props.record?.code) return;
-    const lines = props.record.code.split('\n');
+    if (!name || !record.value?.code) return;
+    const lines = record.value.code.split('\n');
     
     // Handle comma-separated names like "N, K" - search for each part
     const searchTerms = name.split(',').map(s => s.trim()).filter(s => s.length > 0);
@@ -552,12 +720,12 @@ const findCounterExample = async () => {
     loadingAi.value = true;
     try {
         const res = await aiApi.generateCounterExample({
-            recordId: props.record.id,
-            problemNumber: String(props.record.problemNumber),
-            code: props.record.code,
-            language: props.record.language,
-            platform: props.record.platform,
-            problemTitle: props.record.title
+            recordId: record.value.id,
+            problemNumber: String(record.value.problemNumber),
+            code: record.value.code,
+            language: record.value.language,
+            platform: record.value.platform,
+            problemTitle: record.value.title
         });
         aiData.value = res.data;
     } catch (e) {
@@ -573,60 +741,48 @@ const sendTutorMessage = async () => {
     const userMsg = tutorInput.value;
     tutorMessages.value.push({ role: 'user', content: userMsg });
     tutorInput.value = '';
-    
-    // Add temporary loading message
     const loadingMsg = { role: 'assistant', content: '', isLoading: true };
     tutorMessages.value.push(loadingMsg);
     loadingTutorResponse.value = true;
-    
-    // Auto-scroll
-    nextTick(() => { if(chatContainer.value) chatContainer.value.scrollTop = chatContainer.value.scrollHeight; });
+    nextTick(() => { if (chatContainer.value) chatContainer.value.scrollTop = chatContainer.value.scrollHeight; });
 
-    // History excludes current & loading
-    // We already pushed userMsg and loadingMsg, so slice -2 to get history before this turn
-    const history = tutorMessages.value.slice(0, -2).map(m => ({ 
-        role: m.role === 'user' ? 'user' : 'assistant', 
-        content: m.content 
+    const history = tutorMessages.value.slice(0, -2).map(m => ({
+        role: m.role === 'user' ? 'user' : 'assistant',
+        content: m.content
     }));
 
     try {
         const res = await aiApi.tutorChat({
              userId: user.value?.id,
-             recordId: props.record.id,
+             recordId: record.value.id,
              message: userMsg,
              solveStatus: isPassed.value ? 'solved' : 'wrong',
-             wrongReason: !isPassed.value ? '틀렸습니다' : null,
-             history: history
+             wrongReason: !isPassed.value ? '오답입니다' : null,
+             history
         });
 
-        // Remove loading message
         tutorMessages.value.pop();
-
         tutorMessages.value.push({ 
             role: 'assistant', 
-            content: res.data.reply || res.data.answer || "답변을 생성할 수 없습니다.",
+            content: res.data.reply || res.data.answer || '응답을 생성하지 못했습니다.',
             suggestions: res.data.followUpQuestions,
             concepts: res.data.relatedConcepts,
             encouragement: res.data.encouragement
         });
-        
+
         emit('acorn-used');
     } catch (e) {
         console.error("Tutor chat failed", e);
-        
-        // Remove loading message
         tutorMessages.value.pop();
-        
         const errorMsg = e.response?.data?.message || '';
         if (errorMsg.includes('Not enough acorns')) {
-             tutorMessages.value.push({ role: 'assistant', content: "도토리가 부족해 응답을 생성할 수 없습니다." });
+             tutorMessages.value.push({ role: 'assistant', content: '도토리가 부족해 응답을 생성할 수 없습니다.' });
         } else {
-             tutorMessages.value.push({ role: 'assistant', content: "죄송합니다, 답변을 생성하는 중 오류가 발생했습니다." });
+             tutorMessages.value.push({ role: 'assistant', content: '죄송합니다. 응답 생성 중 오류가 발생했습니다.' });
         }
     } finally {
         loadingTutorResponse.value = false;
-        // Scroll to bottom after response
-        nextTick(() => { if(chatContainer.value) chatContainer.value.scrollTop = chatContainer.value.scrollHeight; });
+        nextTick(() => { if (chatContainer.value) chatContainer.value.scrollTop = chatContainer.value.scrollHeight; });
     }
 };
 

--- a/frontend/src/views/dashboard/DashboardRecordCard.vue
+++ b/frontend/src/views/dashboard/DashboardRecordCard.vue
@@ -1,485 +1,317 @@
 <template>
-  <div 
-    class="group relative bg-white rounded-3xl shadow-sm transition-all duration-300 hover:shadow-md hover:-translate-y-0.5"
-    :class="{ 'shadow-md': isExpanded, 'ring-2 ring-brand-500/20': props.record.tag === 'MISSION' }"
+  <div
+    class="group relative rounded-3xl bg-white shadow-sm transition-all duration-300 hover:-translate-y-0.5 hover:shadow-md"
+    :class="{ 'shadow-md': isExpanded, 'ring-2 ring-brand-500/20': record.tag === 'MISSION' }"
     @click.stop
   >
-    <!-- 상태 헤더 바 -->
-    <div :class="statusHeaderClass" class="px-5 py-3 flex items-center gap-3 text-sm font-bold rounded-t-3xl cursor-pointer" @click="toggleExpand">
-      <!-- 1. 상태 아이콘 -->
+    <div
+      :class="statusHeaderClass"
+      class="flex cursor-pointer items-center gap-3 rounded-t-3xl px-5 py-3 text-sm font-bold"
+      @click="toggleExpand"
+    >
       <div class="flex items-center gap-1.5">
-          <CheckCircle2 v-if="isPassed" :size="18" class="fill-current" />
-          <X v-else :size="18" />
-          <span>{{ isPassed ? 'SUCCESS' : 'FAILED' }}</span>
+        <CheckCircle2 v-if="isPassed" :size="18" class="fill-current" />
+        <X v-else :size="18" />
+        <span>{{ isPassed ? 'SUCCESS' : 'FAILED' }}</span>
       </div>
 
-      <!-- 구분선 -->
-      <div class="h-3 w-px bg-current opacity-20 mx-1"></div>
+      <div class="mx-1 h-3 w-px bg-current opacity-20"></div>
 
-      <!-- 2. 유형 배지 (TaskBadge 컴포넌트 사용) -->
-      <div class="flex items-center gap-2">
-          <TaskBadge :type="props.record.tag || 'GENERAL'" />
-      </div>
+      <TaskBadge :type="record.tag || 'GENERAL'" />
 
-      <!-- 3. 메타 정보 (고정 위치) -->
-      <div class="flex items-center gap-2 ml-2">
-           <!-- 디펜스 연승 -->
-          <div v-if="props.record.tag === 'DEFENSE' && defenseStreak > 0" 
-               class="flex items-center gap-1 text-orange-600 text-[10px] font-bold bg-orange-50 px-1.5 py-0.5 rounded border border-orange-100">
-              <Flame :size="10" class="fill-orange-500" /> {{ defenseStreak }}연승
-          </div>
-          <!-- 소요 시간 -->
-          <div v-if="props.record.elapsedTimeSeconds && (props.record.tag === 'DEFENSE' || props.record.tag === 'MOCK_EXAM')" 
-               class="flex items-center gap-1 text-slate-500 text-[10px] bg-slate-100 px-1.5 py-0.5 rounded">
-              <Clock :size="10" /> {{ formatElapsedTime(props.record.elapsedTimeSeconds) }}
-          </div>
-      </div>
-      
-      <!-- 오른쪽: 이름/날짜 -->
-      <div class="ml-auto flex items-center gap-3">
-          <!-- 작성자 표시 -->
-          <div class="flex items-center gap-1.5 bg-slate-50 px-2 py-1 rounded-full border border-slate-100">
-              <NicknameRenderer 
-                  :username="record.username" 
-                  :show-avatar="false"
-                  text-class="text-xs font-medium text-slate-600"
-              >
-              </NicknameRenderer>
-          </div>
-
-          <div class="flex items-center gap-2 text-xs opacity-60 font-medium">
-              <span>{{ formatDate(record.createdAt) }}</span>
-          </div>
-      </div>
-    </div>
-
-    <!-- 헤더 / 접힌 뷰 -->
-    <div class="flex flex-col xl:flex-row gap-6 p-6 cursor-pointer" @click="toggleExpand">
-      <!-- 메인 콘텐츠 섹션 -->
-      <div class="flex-1 min-w-0">
-          <div class="flex items-start justify-between gap-4 mb-2">
-              <div class="flex flex-col">
-                  <!-- 뱃지 -->
-                  <div class="flex flex-wrap items-center gap-2 mb-2">
-                    <span 
-                        class="px-2.5 py-1 rounded-lg text-[10px] font-bold uppercase tracking-wider bg-slate-100 text-slate-500 border border-slate-200"
-                    >
-                        #{{ record.problemNumber }}
-                    </span>
-                    <span 
-                        class="px-2.5 py-1 rounded-lg text-[10px] font-bold uppercase tracking-wider border"
-                        :class="(record.runtimeMs !== null && record.runtimeMs !== -1 && record.memoryKb > 0) ? 'bg-white border-slate-200 text-slate-600' : 'bg-rose-50 border-rose-100 text-rose-600'"
-                    >
-                        {{ record.language }}
-                    </span>
-                    
-                    <!-- 플랫폼 뱃지 (제목 옆에서 이동) -->
-                    <span v-if="platformBadge" 
-                          class="px-2.5 py-1 rounded-lg text-[10px] font-bold border"
-                          :class="platformBadgeClass">
-                        {{ platformBadge }}
-                    </span>
-                  </div>
-                  
-                  <!-- 제목 -->
-                  <h3 class="text-lg md:text-xl font-bold text-slate-800 leading-tight group-hover:text-brand-600 transition-colors flex items-center gap-2">
-                      {{ record.title }}
-                  </h3>
-              </div>
-               <div class="text-slate-400">
-                  <ChevronDown v-if="!isExpanded" :size="20" />
-                  <ChevronUp v-else :size="20" class="text-brand-500" />
-               </div>
-          </div>
-      </div>
-    </div>
-
-    <!-- 확장 뷰: 코드 뷰어 전용 -->
-    <div v-if="isExpanded" class="animate-slide-down bg-slate-50 relative rounded-b-3xl overflow-hidden border-t border-slate-100">
-        <div class="flex flex-col">
-            <div class="rounded-xl overflow-hidden">
-                <CodeViewer
-                    ref="codeViewerRef"
-                    :code="record.code"
-                    :language="record.language || 'java'"
-                    :filename="`${record.title}.${getExtension(record.language)}`"
-                    :comments="comments"
-                    :keyBlocks="combinedHighlights"
-                    @submit-comment="submitLineComment"
-                    :readOnly="false" 
-                />
-            </div>
+      <div class="ml-2 flex items-center gap-2">
+        <div
+          v-if="record.tag === 'DEFENSE' && defenseStreak > 0"
+          class="flex items-center gap-1 rounded border border-orange-100 bg-orange-50 px-1.5 py-0.5 text-[10px] font-bold text-orange-600"
+        >
+          <Flame :size="10" class="fill-orange-500" /> {{ defenseStreak }}연속
         </div>
+        <div
+          v-if="record.elapsedTimeSeconds && (record.tag === 'DEFENSE' || record.tag === 'MOCK_EXAM')"
+          class="flex items-center gap-1 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-500"
+        >
+          <Clock :size="10" /> {{ formatElapsedTime(record.elapsedTimeSeconds) }}
+        </div>
+      </div>
+
+      <div class="ml-auto flex items-center gap-3">
+        <div class="flex items-center gap-1.5 rounded-full border border-slate-100 bg-slate-50 px-2 py-1">
+          <NicknameRenderer
+            :username="record.username"
+            :show-avatar="false"
+            text-class="text-xs font-medium text-slate-600"
+          />
+        </div>
+        <div class="flex items-center gap-2 text-xs font-medium opacity-60">
+          <span>{{ formatDate(record.createdAt) }}</span>
+        </div>
+      </div>
     </div>
 
+    <div class="flex cursor-pointer flex-col gap-6 p-6 xl:flex-row" @click="toggleExpand">
+      <div class="min-w-0 flex-1">
+        <div class="mb-2 flex items-start justify-between gap-4">
+          <div class="flex flex-col">
+            <div class="mb-2 flex flex-wrap items-center gap-2">
+              <span class="rounded-lg border border-slate-200 bg-slate-100 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                #{{ record.problemNumber }}
+              </span>
+              <span
+                class="rounded-lg border px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider"
+                :class="isPassed ? 'border-slate-200 bg-white text-slate-600' : 'border-rose-100 bg-rose-50 text-rose-600'"
+              >
+                {{ record.language }}
+              </span>
+              <span
+                v-if="platformBadge"
+                class="rounded-lg border px-2.5 py-1 text-[10px] font-bold"
+                :class="platformBadgeClass"
+              >
+                {{ platformBadge }}
+              </span>
+              <span
+                class="rounded-lg border px-2.5 py-1 text-[10px] font-bold"
+                :class="hasAnyAnalysis ? 'border-emerald-100 bg-emerald-50 text-emerald-600' : 'border-amber-100 bg-amber-50 text-amber-600'"
+              >
+                {{ hasAnyAnalysis ? '분석 완료' : '클릭 시 AI 분석 생성' }}
+              </span>
+            </div>
+
+            <h3 class="flex items-center gap-2 text-lg font-bold leading-tight text-slate-800 transition-colors group-hover:text-brand-600 md:text-xl">
+              {{ record.title }}
+            </h3>
+          </div>
+
+          <div class="text-slate-400">
+            <ChevronDown v-if="!isExpanded" :size="20" />
+            <ChevronUp v-else :size="20" class="text-brand-500" />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="isExpanded" class="relative overflow-hidden rounded-b-3xl border-t border-slate-100 bg-slate-50 animate-slide-down">
+      <div class="flex flex-col">
+        <div class="overflow-hidden rounded-xl">
+          <CodeViewer
+            ref="codeViewerRef"
+            :code="record.code"
+            :language="record.language || 'java'"
+            :filename="`${record.title}.${getExtension(record.language)}`"
+            :comments="comments"
+            :key-blocks="combinedHighlights"
+            :read-only="false"
+            @submit-comment="submitLineComment"
+          />
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { ref, watch, computed, nextTick } from 'vue';
-import { ExternalLink, ChevronDown, ChevronUp, Bot, Bug, Send, Loader2, Activity, LayoutList, Lightbulb, Tag, MessageSquare, Wand2, CheckCircle2, BookOpen, Footprints, HelpCircle, Trophy, Clock, X, Shield, Package, Key, Flame, Sparkles, MessageCircle, Copy, User, Code2 } from 'lucide-vue-next';
+import { computed, nextTick, ref, watch } from 'vue';
+import { CheckCircle2, ChevronDown, ChevronUp, Clock, Flame, Key, X } from 'lucide-vue-next';
 import CodeViewer from '@/components/editor/CodeViewer.vue';
 import TaskBadge from '@/components/common/TaskBadge.vue';
 import NicknameRenderer from '@/components/common/NicknameRenderer.vue';
 import { boardApi, commentApi } from '@/api/board';
-import { aiApi } from '@/api/ai'; 
-import { useAuth } from '@/composables/useAuth';
-import { marked } from 'marked';
 
 const props = defineProps({
   record: { type: Object, required: true },
   isExpanded: { type: Boolean, default: false }
 });
 
-const emit = defineEmits(['find-counter-example', 'ask-tutor', 'toggle-expand']);
+const emit = defineEmits(['toggle-expand']);
 
-const { user } = useAuth();
-
-const loadingBoard = ref(false);
 const board = ref(null);
 const comments = ref([]);
-
-// 탭
-const activeTab = ref('overview');
-const tabs = [
-    { id: 'overview', label: '개요' },
-    { id: 'analysis', label: '분석' },
-    { id: 'counter', label: '반례' },
-    { id: 'tutor', label: '튜터' }
-];
-
-// AI & 채팅 상태
-const loadingAi = ref(false);
-const aiData = ref(props.record.counterExampleInput ? {
-    input: props.record.counterExampleInput,
-    expected: props.record.counterExampleExpected,
-    predicted: props.record.counterExamplePredicted,
-    reason: props.record.counterExampleReason
-} : null);
-const tutorInput = ref('');
-const tutorMessages = ref([]);
-const loadingTutorResponse = ref(false);
-const chatContainer = ref(null);
+const loadingBoard = ref(false);
 const codeViewerRef = ref(null);
-const commentsScrollContainer = ref(null);
 
-// 개요 탭 상태
-const showTrace = ref(false);
-const overviewCommentInput = ref('');
-// 분석 탭 상태
-const showComplexityExplanation = ref(false);
+const record = computed(() => props.record);
 
-const toggleTrace = () => {
-    showTrace.value = !showTrace.value;
-};
-
-const submitOverviewComment = async () => {
-    if (!overviewCommentInput.value.trim()) return;
-    await submitLineComment({ lineNumber: null, content: overviewCommentInput.value.trim() });
-    overviewCommentInput.value = '';
-};
-
-// 메서드
-const toggleExpand = () => {
-    console.log('Card: Emitting toggle-expand for', props.record.id);
-    emit('toggle-expand', props.record.id);
-};
-
-// 데이터 로드를 위한 확장 감지
-watch(() => props.isExpanded, async (newVal) => {
-    if (newVal && !board.value) {
-        await loadBoardAndComments();
+watch(
+  () => props.isExpanded,
+  async (expanded) => {
+    if (expanded && !board.value) {
+      await loadBoardAndComments();
     }
-});
+  }
+);
 
-// 새 댓글 추가 시 자동 스크롤
-watch(comments, () => {
-    nextTick(() => {
-        if (commentsScrollContainer.value) {
-            commentsScrollContainer.value.scrollTop = commentsScrollContainer.value.scrollHeight;
-        }
-    });
-}, { deep: true });
+const toggleExpand = () => {
+  emit('toggle-expand', props.record.id);
+};
 
 const loadBoardAndComments = async () => {
-    loadingBoard.value = true;
-    try {
-        const res = await boardApi.findByRecordId(props.record.id);
-        if (res.status === 204 || !res.data) {
-            board.value = null;
-            comments.value = [];
-        } else {
-            board.value = res.data;
-            const commentsRes = await commentApi.findByBoardId(board.value.id);
-            comments.value = commentsRes.data || [];
-        }
-    } catch (e) {
-        console.error("Failed to load review info", e);
-    } finally {
-        loadingBoard.value = false;
+  loadingBoard.value = true;
+  try {
+    const boardResponse = await boardApi.findByRecordId(props.record.id);
+    if (boardResponse.status === 204 || !boardResponse.data) {
+      board.value = null;
+      comments.value = [];
+      return;
     }
-};
 
-const scrollToLine = (lineNumber, endLine = null) => {
-    console.log("Dashboard: scrollToLine", lineNumber, endLine, "Ref:", !!codeViewerRef.value);
-    if (codeViewerRef.value && lineNumber) {
-        codeViewerRef.value.scrollToLine(Number(lineNumber), endLine ? Number(endLine) : null);
-    }
-};
-
-const scrollToStructure = (name) => {
-    if (!name || !props.record.code) return;
-    const lines = props.record.code.split('\n');
-    const target = name.trim();
-    // Simple search: find first line containing the name
-    // Could be improved with regex or exact match, but contains is usually sufficient for navigation
-    const index = lines.findIndex(line => line.includes(target));
-    if (index !== -1) {
-        scrollToLine(index + 1);
-    }
+    board.value = boardResponse.data;
+    const commentsResponse = await commentApi.findByBoardId(board.value.id);
+    comments.value = commentsResponse.data || [];
+  } catch (error) {
+    console.error('Failed to load review info', error);
+  } finally {
+    loadingBoard.value = false;
+  }
 };
 
 const ensureBoardExists = async () => {
-    if (board.value) return board.value;
-    try {
-        const res = await boardApi.create({
-            title: `${props.record.title}`,
-            content: `Code review for ${props.record.title} (${props.record.problemNumber})`,
-            boardType: 'CODE_REVIEW',
-            visibility: 'PRIVATE',
-            algorithmRecordId: props.record.id
-        });
-        board.value = res.data;
-        return board.value;
-    } catch (e) { 
-        console.error("Failed to create review board", e); throw e; 
-    }
+  if (board.value) return board.value;
+
+  const response = await boardApi.create({
+    title: props.record.title,
+    content: `Code review for ${props.record.title} (${props.record.problemNumber})`,
+    boardType: 'CODE_REVIEW',
+    visibility: 'PRIVATE',
+    algorithmRecordId: props.record.id
+  });
+
+  board.value = response.data;
+  return board.value;
 };
 
 const submitLineComment = async ({ lineNumber, content }) => {
-    try {
-        const targetBoard = await ensureBoardExists();
-        const res = await commentApi.create(targetBoard.id, { content, lineNumber });
-        comments.value.push(res.data);
-    } catch (e) { console.error("Failed to submit comment", e); }
+  try {
+    const targetBoard = await ensureBoardExists();
+    const response = await commentApi.create(targetBoard.id, { content, lineNumber });
+    comments.value.push(response.data);
+  } catch (error) {
+    console.error('Failed to submit comment', error);
+  }
 };
 
-// AI 로직
-const findCounterExample = async () => {
-    loadingAi.value = true;
-    try {
-        const res = await aiApi.generateCounterExample({
-            recordId: props.record.id,
-            problemNumber: String(props.record.problemNumber),
-            code: props.record.code,
-            language: props.record.language,
-            platform: props.record.platform,
-            problemTitle: props.record.title
-        });
-        aiData.value = res.data;
-    } catch (e) {
-        console.error("Failed to find counter example", e);
-        alert("반례 생성에 실패했습니다.");
-    } finally {
-        loadingAi.value = false;
-    }
+const scrollToLine = (lineNumber, endLine = null) => {
+  if (codeViewerRef.value && lineNumber) {
+    codeViewerRef.value.scrollToLine(Number(lineNumber), endLine ? Number(endLine) : null);
+  }
 };
 
-const copyToClipboard = async (text) => {
-    if (!text) return;
-    try {
-        await navigator.clipboard.writeText(text);
-    // 추후 토스트 알림 추가 가능
-    } catch (err) {
-        console.error('Failed to copy text: ', err);
-    }
+const formatDate = (value) => {
+  if (!value) return '';
+  return new Date(value).toLocaleDateString('ko-KR', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
 };
-
-const sendTutorMessage = async () => {
-    if (!tutorInput.value.trim()) return;
-    const userMsg = tutorInput.value;
-    tutorMessages.value.push({ role: 'user', content: userMsg });
-    tutorInput.value = '';
-    loadingTutorResponse.value = true;
-    
-    // 자동 스크롤
-    nextTick(() => { if(chatContainer.value) chatContainer.value.scrollTop = chatContainer.value.scrollHeight; });
-
-    // 로딩 플레이스홀더 추가
-    tutorMessages.value.push({ role: 'assistant', isLoading: true });
-    nextTick(() => { if(chatContainer.value) chatContainer.value.scrollTop = chatContainer.value.scrollHeight; });
-
-    // 현재 메시지와 로딩은 히스토리에서 제외
-    const history = tutorMessages.value.slice(0, -2).map(m => ({ 
-        role: m.role === 'user' ? 'user' : 'assistant', 
-        content: m.content 
-    }));
-
-    try {
-        const res = await aiApi.tutorChat({
-             userId: user.value?.id,
-             recordId: props.record.id,
-             message: userMsg,
-             solveStatus: isPassed.value ? 'solved' : 'wrong',
-             wrongReason: !isPassed.value ? '틀렸습니다' : null,
-             history: history
-        });
-        
-        // 로딩 플레이스홀더 제거
-        tutorMessages.value.pop();
-
-        tutorMessages.value.push({ 
-            role: 'assistant', 
-            content: res.data.reply || res.data.answer || "답변을 생성할 수 없습니다.",
-            suggestions: res.data.followUpQuestions,
-            concepts: res.data.relatedConcepts,
-            encouragement: res.data.encouragement
-        });
-    } catch (e) {
-        tutorMessages.value.pop(); // Remove placeholder
-        console.error("Tutor chat failed", e);
-        tutorMessages.value.push({ role: 'assistant', content: "죄송합니다, 답변을 생성하는 중 오류가 발생했습니다." });
-    } finally {
-        loadingTutorResponse.value = false;
-        nextTick(() => { if(chatContainer.value) chatContainer.value.scrollTop = chatContainer.value.scrollHeight; });
-    }
-};
-
-
-const sendSuggestion = (q) => {
-    tutorInput.value = q;
-    sendTutorMessage();
-};
-
-// 헬퍼 함수
-const formatDate = (d) => d ? new Date(d).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '';
-const getExtension = (l) => ({'java':'java','python':'py','cpp':'cpp','c':'c','javascript':'js'}[l?.toLowerCase()] || 'txt');
 
 const formatElapsedTime = (seconds) => {
-    if (!seconds || seconds < 0) return '';
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    if (mins === 0) return `${secs}초`;
-    if (secs === 0) return `${mins}분`;
-    return `${mins}분 ${secs}초`;
+  if (!seconds || seconds < 0) return '';
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+
+  if (minutes === 0) return `${remainingSeconds}초`;
+  if (remainingSeconds === 0) return `${minutes}분`;
+  return `${minutes}분 ${remainingSeconds}초`;
 };
 
-const extractPatterns = (json) => {
-    if (!json) return [];
-    try { 
-        const parsed = Array.isArray(JSON.parse(json)) ? JSON.parse(json) : [];
-        // Flatten: If a pattern string contains commas, split it.
-        return parsed.flatMap(p => p.split(',').map(s => s.trim()).filter(s => s.length > 0)); 
-    } catch { return []; }
-};
+const getExtension = (language) => ({
+  java: 'java',
+  python: 'py',
+  cpp: 'cpp',
+  c: 'c',
+  javascript: 'js'
+}[language?.toLowerCase()] || 'txt');
 
-const renderMarkdown = (text) => text ? marked.parse(text) : '';
-
-// Computed 속성
-const parsedKeyBlocks = computed(() => {
-    if (!props.record.keyBlocks) return [];
-    try { return Array.isArray(JSON.parse(props.record.keyBlocks)) ? JSON.parse(props.record.keyBlocks) : []; } catch { return []; }
+const parsedFullResponse = computed(() => {
+  if (!props.record.fullResponse) return null;
+  try {
+    return JSON.parse(props.record.fullResponse);
+  } catch {
+    return null;
+  }
 });
 
 const parsedStructure = computed(() => {
-    if (!props.record.fullResponse) return [];
-    try {
-        const full = JSON.parse(props.record.fullResponse);
-        return Array.isArray(full.structure) ? full.structure : [];
-    } catch { return []; }
+  const structure = parsedFullResponse.value?.structure;
+  return Array.isArray(structure) ? structure : [];
 });
 
-// Type별 분리 - 변수 (variable, constant)
-const parsedVariables = computed(() => {
-    return parsedStructure.value.filter(item => 
-        !item.type || item.type === 'variable' || item.type === 'constant'
-    );
-});
-
-// Type별 분리 - 함수 (function, class)
-const parsedFunctions = computed(() => {
-    return parsedStructure.value.filter(item => 
-        item.type === 'function' || item.type === 'class'
-    );
-});
-
-
-
-const parsedFullResponse = computed(() => {
-    if (!props.record.fullResponse) return null;
-    try { return JSON.parse(props.record.fullResponse); } catch { return null; }
+const parsedKeyBlocks = computed(() => {
+  if (!props.record.keyBlocks) return [];
+  try {
+    const parsed = JSON.parse(props.record.keyBlocks);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
 });
 
 const parsedSummary = computed(() => parsedFullResponse.value?.summary || null);
+const parsedIntuition = computed(() => parsedFullResponse.value?.algorithm?.intuition || props.record.algorithmIntuition || null);
 
-const parsedTraceExample = computed(() => parsedFullResponse.value?.traceExample || null);
-
-const parsedIntuition = computed(() => {
-    return parsedFullResponse.value?.algorithm?.intuition || props.record.algorithmIntuition || null;
-});
-
-const latestSuggestions = computed(() => {
-    const lastMsg = tutorMessages.value.slice().reverse().find(m => m.role === 'assistant');
-    return lastMsg && lastMsg.suggestions ? lastMsg.suggestions : [];
+const parsedPitfalls = computed(() => {
+  if (!props.record.pitfalls) return [];
+  try {
+    const parsed = JSON.parse(props.record.pitfalls);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
 });
 
 const combinedHighlights = computed(() => {
-    const structure = parsedStructure.value.map(item => ({
-        ...item,
-        code: item.name,
-        explanation: `[구조] ${item.role}`
-    }));
-    const keyBlocks = parsedKeyBlocks.value.map(block => ({
-        ...block,
-        code: block.code,
-        explanation: `[로직] ${block.explanation}`
-    }));
-    return [...structure, ...keyBlocks];
+  const structureHighlights = parsedStructure.value.map((item) => ({
+    ...item,
+    code: item.name,
+    explanation: `[구조] ${item.role}`
+  }));
+
+  const blockHighlights = parsedKeyBlocks.value.map((block) => ({
+    ...block,
+    code: block.code,
+    explanation: `[로직] ${block.explanation}`
+  }));
+
+  return [...structureHighlights, ...blockHighlights];
 });
 
-const parsedPitfalls = computed(() => {
-    if (!props.record.pitfalls) return [];
-    try { return JSON.parse(props.record.pitfalls); } catch (e) { return []; }
-});
+const hasAnyAnalysis = computed(() => Boolean(
+  props.record.timeComplexity ||
+  props.record.spaceComplexity ||
+  props.record.fullResponse ||
+  parsedPitfalls.value.length > 0 ||
+  props.record.refactorProvided
+));
 
-const hasAnyAnalysis = computed(() => props.record.timeComplexity || parsedPitfalls.value.length > 0 || props.record.refactorProvided);
 const isPassed = computed(() => {
-    const runtime = props.record.runtimeMs;
-    const memory = props.record.memoryKb;
-    return props.record.result === 'SUCCESS' || props.record.result === 'PASSED' || (runtime !== null && runtime !== undefined && runtime !== -1 && memory > 0);
+  const runtime = props.record.runtimeMs;
+  const memory = props.record.memoryKb;
+  return props.record.result === 'SUCCESS' || props.record.result === 'PASSED' || (runtime !== null && runtime !== undefined && runtime !== -1 && memory > 0);
 });
 
-const taskTypeLabel = computed(() => ({'MISSION':'과제','MOCK_EXAM':'모의고사','DEFENSE':'디펜스','GENERAL':'일반'}[props.record.tag]));
 const defenseStreak = computed(() => props.record.defenseStreak || 0);
 
 const platformBadge = computed(() => {
-    const p = props.record.platform?.toLowerCase();
-    if (p === 'baekjoon' || p === 'boj') return 'BOJ';
-    if (p === 'swea') return 'SWEA';
-    if (p === 'programmers' || p === 'pgs') return 'PGS';
-    return null;
+  const platform = props.record.platform?.toLowerCase();
+  if (platform === 'baekjoon' || platform === 'boj') return 'BOJ';
+  if (platform === 'swea') return 'SWEA';
+  if (platform === 'programmers' || platform === 'pgs') return 'PGS';
+  return null;
 });
 
 const platformBadgeClass = computed(() => {
-    const p = platformBadge.value;
-    if (p === 'BOJ') return 'bg-blue-50 text-blue-600 border-blue-100';
-    if (p === 'SWEA') return 'bg-cyan-50 text-cyan-600 border-cyan-100';
-    if (p === 'PGS') return 'bg-slate-800 text-white border-slate-700'; 
-    return 'bg-slate-50 text-slate-500 border-slate-200';
+  if (platformBadge.value === 'BOJ') return 'bg-blue-50 text-blue-600 border-blue-100';
+  if (platformBadge.value === 'SWEA') return 'bg-cyan-50 text-cyan-600 border-cyan-100';
+  if (platformBadge.value === 'PGS') return 'bg-slate-800 text-white border-slate-700';
+  return 'bg-slate-50 text-slate-500 border-slate-200';
 });
 
-const statusHeaderClass = computed(() => {
-    // PASS -> Emerald Green
-    // FAIL -> Rose Red (or Slate if you prefer neutral, but Request said "Red")
-    return isPassed.value 
-        ? 'bg-emerald-50 text-emerald-700 border-b border-emerald-100' 
-        : 'bg-rose-50 text-rose-700 border-b border-rose-100';
-});
-
-const cardBorderClass = computed(() => {
-    // Remove old logic, handled in template
-    return {};
-});
+const statusHeaderClass = computed(() => (
+  isPassed.value
+    ? 'border-b border-emerald-100 bg-emerald-50 text-emerald-700'
+    : 'border-b border-rose-100 bg-rose-50 text-rose-700'
+));
 
 defineExpose({ scrollToLine });
 </script>
@@ -487,13 +319,4 @@ defineExpose({ scrollToLine });
 <style scoped>
 .animate-slide-down { animation: slide-down 0.3s ease-out forwards; }
 @keyframes slide-down { from { opacity: 0; transform: translateY(-10px); } to { opacity: 1; transform: translateY(0); } }
-.custom-scrollbar::-webkit-scrollbar { width: 4px; height: 4px; }
-.custom-scrollbar::-webkit-scrollbar-track { background: transparent; }
-.custom-scrollbar::-webkit-scrollbar-thumb { background-color: #cbd5e1; border-radius: 2px; }
-
-.animate-fade-in-left { animation: fade-in-left 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
-@keyframes fade-in-left { from { opacity: 0; transform: translateX(-20px); } to { opacity: 1; transform: translateX(0); } }
-
-.animate-fade-in-right { animation: fade-in-right 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
-@keyframes fade-in-right { from { opacity: 0; transform: translateX(20px); } to { opacity: 1; transform: translateX(0); } }
 </style>

--- a/frontend/src/views/dashboard/DashboardView.vue
+++ b/frontend/src/views/dashboard/DashboardView.vue
@@ -525,7 +525,7 @@
 
                 <!-- 3. 분석 사이드바 (컨텍스트) -->
                 <div class="flex-1 min-h-0 overflow-hidden rounded-2xl border border-slate-200 shadow-sm bg-white" @click.stop>
-                     <AnalysisSidebar :record="activeAnalysisRecord" @scroll-to-line="handleScrollToLine" @acorn-used="handleAcornUsed" />
+                     <AnalysisSidebar :record="activeAnalysisRecord" @scroll-to-line="handleScrollToLine" @acorn-used="handleAcornUsed" @analysis-loaded="handleAnalysisLoaded" />
                 </div>
 
 
@@ -1006,6 +1006,22 @@ const handleScrollToLine = ({ start, end }) => {
     console.log('Dashboard: handleScrollToLine', start, end, 'activeCardRef:', !!activeCardRef.value);
     if (activeCardRef.value && activeCardRef.value.scrollToLine) {
         activeCardRef.value.scrollToLine(start, end);
+    }
+};
+
+const handleAnalysisLoaded = (nextRecord) => {
+    if (!nextRecord?.id) return;
+
+    records.value = records.value.map(record => (
+        record.id === nextRecord.id ? { ...record, ...nextRecord } : record
+    ));
+
+    if (activeAnalysisRecord.value?.id === nextRecord.id) {
+        activeAnalysisRecord.value = { ...activeAnalysisRecord.value, ...nextRecord };
+    }
+
+    if (currentDrawerRecord.value?.id === nextRecord.id) {
+        currentDrawerRecord.value = { ...currentDrawerRecord.value, ...nextRecord };
     }
 };
 

--- a/frontend/src/views/study/StudyManageView.vue
+++ b/frontend/src/views/study/StudyManageView.vue
@@ -1,0 +1,392 @@
+<script setup>
+import { ref, onMounted, computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { studyApi } from '@/api/study';
+import { useAuth } from '@/composables/useAuth';
+import { 
+  Settings, Users, Crown, Trash2, UserCheck, 
+  ChevronLeft, Loader2, Save, AlertTriangle, X, Check
+} from 'lucide-vue-next';
+import BaseIconBadge from '@/components/common/BaseIconBadge.vue';
+
+const router = useRouter();
+const { user, refresh } = useAuth();
+
+// State
+const loading = ref(true);
+const saving = ref(false);
+const study = ref({
+  id: null,
+  name: '',
+  description: '',
+  creatorId: null
+});
+
+// Member Management
+const memberList = ref([]);
+const loadingMembers = ref(false);
+const showDelegateModal = ref(false);
+const selectedMemberId = ref(null);
+
+// Dissolution
+const showDeleteConfirmModal = ref(false);
+const deleteInput = ref('');
+
+onMounted(async () => {
+  if (!user.value?.studyId) {
+    router.replace('/training/roadmap');
+    return;
+  }
+
+  try {
+    const res = await studyApi.get(user.value.studyId);
+    study.value = res.data;
+    
+    // Check leadership
+    if (study.value.creatorId !== user.value.id && user.value.role !== 'ROLE_ADMIN') {
+      alert("스터디장만 접근 가능합니다.");
+      router.replace('/dashboard');
+    }
+  } catch (e) {
+    console.error("Failed to load study info", e);
+    alert("스터디 정보를 불러오지 못했습니다.");
+    router.replace('/dashboard');
+  } finally {
+    loading.value = false;
+  }
+});
+
+const handleSave = async () => {
+  if (!study.value.name.trim()) return;
+  saving.value = true;
+  try {
+    await studyApi.update(study.value.id, {
+      name: study.value.name,
+      description: study.value.description
+    });
+    alert("스터디 정보가 수정되었습니다.");
+    await refresh(); 
+    router.push('/profile');
+  } catch (e) {
+    console.error(e);
+    alert("수정에 실패했습니다.");
+  } finally {
+    saving.value = false;
+  }
+};
+
+const openDelegateModal = async () => {
+  showDelegateModal.value = true;
+  loadingMembers.value = true;
+  selectedMemberId.value = null;
+  try {
+    const res = await studyApi.getMembers(study.value.id);
+    // Exclude self
+    memberList.value = res.data.filter(m => m.id !== user.value.id);
+  } catch (e) {
+    console.error(e);
+    alert("멤버 목록을 불러오지 못했습니다.");
+    showDelegateModal.value = false;
+  } finally {
+    loadingMembers.value = false;
+  }
+};
+
+const handleDelegate = async () => {
+  if (!selectedMemberId.value) return;
+  if (!confirm("정말로 스터디장 권한을 위임하시겠습니까?\n위임 후에는 일반 멤버로 전환되며, 이 페이지에 다시 접근할 수 없습니다.")) return;
+  
+  try {
+    await studyApi.delegateLeader(study.value.id, selectedMemberId.value);
+    alert("스터디장이 변경되었습니다.");
+    router.replace('/profile');
+  } catch(e) {
+    console.error(e);
+    alert("위임에 실패했습니다.");
+  }
+};
+
+const openDeleteModal = () => {
+  deleteInput.value = '';
+  showDeleteConfirmModal.value = true;
+};
+
+const handleConfirmDelete = async () => {
+  if (deleteInput.value !== study.value.name) return;
+  
+  if (!confirm("정말로 스터디를 해체하시겠습니까?\n이 작업은 되돌릴 수 없으며, 모든 미션과 기록이 영구적으로 삭제됩니다.")) return;
+  
+  try {
+    await studyApi.deleteStudy(study.value.id);
+    alert("스터디가 해체되었습니다.");
+    router.replace('/training/roadmap');
+  } catch (e) {
+    console.error(e);
+    alert(e.response?.data?.message || "해체에 실패했습니다.");
+  }
+};
+
+const goBack = () => {
+  router.back();
+};
+</script>
+
+<template>
+  <div class="min-h-screen bg-slate-50 text-slate-700 font-[Pretendard] pb-20">
+    <!-- Header -->
+    <header class="bg-white border-b border-slate-200 sticky top-0 z-30">
+      <div class="container mx-auto px-6 h-16 flex items-center justify-between max-w-5xl">
+        <div class="flex items-center gap-4">
+          <button @click="goBack" class="p-2 hover:bg-slate-100 rounded-xl transition-colors text-slate-500">
+            <ChevronLeft :size="24" />
+          </button>
+          <h1 class="text-xl font-black text-slate-800 tracking-tight">스터디 관리</h1>
+        </div>
+        <button 
+          @click="handleSave"
+          :disabled="saving || !study.name.trim()"
+          class="px-5 py-2.5 bg-brand-600 hover:bg-brand-700 text-white rounded-xl font-bold transition-all shadow-md shadow-brand-200 disabled:opacity-50 flex items-center gap-2"
+        >
+          <Loader2 v-if="saving" class="animate-spin w-4 h-4" />
+          <Save v-else :size="18" />
+          저장하기
+        </button>
+      </div>
+    </header>
+
+    <main class="container mx-auto px-6 py-10 max-w-5xl">
+      <div v-if="loading" class="flex flex-col items-center justify-center py-20">
+        <Loader2 class="animate-spin text-brand-500 mb-4" :size="48" />
+        <p class="text-slate-400 font-bold">스터디 정보를 불러오는 중...</p>
+      </div>
+
+      <div v-else class="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">
+        <!-- Left Side: Basic Info -->
+        <div class="lg:col-span-7 space-y-6">
+          <section class="bg-white rounded-3xl p-8 shadow-sm border border-slate-100">
+            <h2 class="text-lg font-bold text-slate-800 mb-6 flex items-center gap-2">
+              <Settings :size="20" class="text-brand-500" />
+              기본 정보 수정
+            </h2>
+            
+            <div class="space-y-6">
+              <div>
+                <label class="block text-xs font-bold text-slate-400 mb-2 uppercase">스터디 이름</label>
+                <input 
+                  v-model="study.name"
+                  type="text"
+                  placeholder="스터디 이름을 입력하세요"
+                  class="w-full bg-slate-50 border-2 border-slate-100 rounded-2xl px-4 py-3.5 font-bold text-slate-700 focus:outline-none focus:border-brand-500 focus:bg-white transition-all"
+                />
+              </div>
+
+              <div>
+                <label class="block text-xs font-bold text-slate-400 mb-2 uppercase">스터디 소개</label>
+                <textarea 
+                  v-model="study.description"
+                  rows="4"
+                  placeholder="스터디를 소개하는 글을 적어주세요"
+                  class="w-full bg-slate-50 border-2 border-slate-100 rounded-2xl px-4 py-3.5 font-medium text-slate-700 focus:outline-none focus:border-brand-500 focus:bg-white transition-all resize-none"
+                ></textarea>
+              </div>
+            </div>
+          </section>
+
+          <!-- Integration Tips -->
+          <div class="bg-indigo-50 border border-indigo-100 rounded-3xl p-6 flex gap-4">
+            <div class="bg-indigo-100 p-3 rounded-2xl h-fit">
+              <Settings class="w-6 h-6 text-indigo-600" />
+            </div>
+            <div>
+              <h3 class="font-bold text-indigo-900 mb-1">스터디 관리 팁</h3>
+              <p class="text-sm text-indigo-700 leading-relaxed break-keep">
+                <span class="block">스터디 이름이나 소개글을 변경하면 모든 스터디원에게 즉시 반영됩니다.</span>
+                <span class="block">멋진 소개글로 새로운 팀원을 모집해보세요!</span>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Right Side: Leader Actions -->
+        <div class="lg:col-span-5 space-y-6">
+          <section class="bg-white rounded-3xl p-8 shadow-sm border border-slate-100">
+            <h2 class="text-lg font-bold text-slate-800 mb-6 flex items-center gap-2">
+              <Crown :size="20" class="text-orange-500" />
+              스터디장 전용 작업
+            </h2>
+
+            <div class="space-y-4">
+              <!-- Delegation -->
+              <button 
+                @click="openDelegateModal"
+                class="w-full group px-6 py-5 bg-slate-50 hover:bg-brand-50 border border-slate-100 hover:border-brand-100 rounded-2xl transition-all text-left flex items-center justify-between"
+              >
+                <div class="flex items-center gap-4">
+                  <div class="p-3 bg-white group-hover:bg-brand-100 rounded-xl transition-colors shadow-sm">
+                    <UserCheck :size="20" class="text-slate-400 group-hover:text-brand-600" />
+                  </div>
+                  <div>
+                    <div class="font-bold text-slate-700 group-hover:text-brand-900">스터디장 위임</div>
+                    <div class="text-xs text-slate-400 group-hover:text-brand-600">권한을 다른 멤버에게 넘깁니다</div>
+                  </div>
+                </div>
+              </button>
+
+              <!-- Dissolution -->
+              <button 
+                @click="openDeleteModal"
+                class="w-full group px-6 py-5 bg-slate-50 hover:bg-red-50 border border-slate-100 hover:border-red-100 rounded-2xl transition-all text-left flex items-center justify-between"
+              >
+                <div class="flex items-center gap-4">
+                  <div class="p-3 bg-white group-hover:bg-red-100 rounded-xl transition-colors shadow-sm">
+                    <Trash2 :size="20" class="text-slate-400 group-hover:text-red-500" />
+                  </div>
+                  <div>
+                    <div class="font-bold text-slate-700 group-hover:text-red-900">스터디 해체</div>
+                    <div class="text-xs text-slate-400 group-hover:text-red-500">모든 정보와 기록을 삭제합니다</div>
+                  </div>
+                </div>
+              </button>
+            </div>
+          </section>
+
+          <!-- Warning Zone -->
+          <div class="bg-amber-50 border border-amber-100 rounded-3xl p-6 flex gap-4">
+            <AlertTriangle class="w-6 h-6 text-amber-500 shrink-0" />
+            <p class="text-xs text-amber-700 font-medium leading-relaxed break-keep">
+              <span class="block">스터디장 권한 위임이나 스터디 해체는 되돌릴 수 없는 작업입니다.</span>
+              <span class="block">신중하게 결정해주세요.</span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Delegation Modal -->
+    <Teleport to="body">
+      <div v-if="showDelegateModal" class="fixed inset-0 z-[9000] flex items-center justify-center p-4">
+        <div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" @click="showDelegateModal = false"></div>
+        <div class="relative bg-white rounded-3xl w-full max-w-md p-8 shadow-2xl animate-in fade-in zoom-in-95 duration-200">
+          <div class="flex items-center justify-between mb-6">
+            <h3 class="text-xl font-bold text-slate-800">스터디장 위임</h3>
+            <button @click="showDelegateModal = false" class="p-2 hover:bg-slate-100 rounded-full transition-colors">
+              <X :size="20" class="text-slate-400" />
+            </button>
+          </div>
+          
+          <p class="text-sm text-slate-500 mb-6">새로운 스터디장을 선택해주세요.</p>
+          
+          <div v-if="loadingMembers" class="py-12 flex flex-col items-center gap-3 mb-10">
+            <Loader2 class="animate-spin text-brand-500" :size="32"/>
+            <p class="text-xs text-slate-400 font-bold">멤버 목록 불러오는 중...</p>
+          </div>
+          
+          <div v-else-if="memberList.length === 0" class="py-12 text-center text-slate-400 font-bold bg-slate-50 rounded-2xl px-6 mb-10">
+            <Users class="w-12 h-12 text-slate-200 mx-auto mb-3" />
+            위임할 수 있는 다른 멤버가 없습니다.<br>
+            <span class="text-xs font-normal mt-2 block">멤버가 최소 2명 이상이어야 위임이 가능합니다.</span>
+          </div>
+
+          <div v-else class="space-y-3 max-h-[300px] overflow-y-auto mb-10 pr-1 custom-scrollbar">
+            <label 
+              v-for="member in memberList" 
+              :key="member.id"
+              class="flex items-center gap-4 p-4 rounded-2xl border-2 cursor-pointer transition-all"
+              :class="selectedMemberId === member.id ? 'border-brand-500 bg-brand-50 shadow-sm shadow-brand-100' : 'border-slate-50 hover:border-slate-200'"
+            >
+              <input type="radio" :value="member.id" v-model="selectedMemberId" class="hidden">
+              <img :src="member.avatarUrl || '/images/profiles/default-profile.png'" class="w-12 h-12 rounded-2xl bg-slate-100 object-cover border border-slate-100 shadow-sm" />
+              <div class="flex-1">
+                <div class="font-bold text-slate-700">{{ member.username }}</div>
+                <div class="text-xs text-slate-400">Tier: {{ member.solvedacTier }}</div>
+              </div>
+              <div v-if="selectedMemberId === member.id" class="w-6 h-6 bg-brand-500 text-white rounded-full flex items-center justify-center">
+                <Check :size="14" stroke-width="3" />
+              </div>
+            </label>
+          </div>
+
+          <div class="flex gap-3">
+            <button 
+                @click="showDelegateModal = false"
+                class="flex-1 py-4 rounded-2xl font-bold text-slate-500 border border-slate-200 hover:bg-slate-50 transition-colors"
+            >
+                취소
+            </button>
+            <button 
+                @click="handleDelegate"
+                :disabled="!selectedMemberId"
+                class="flex-1 py-4 rounded-2xl font-bold text-white bg-brand-400 hover:bg-brand-500 transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-brand-100"
+            >
+                위임하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Dissolution Confirmation Modal -->
+    <Teleport to="body">
+      <div v-if="showDeleteConfirmModal" class="fixed inset-0 z-[9000] flex items-center justify-center p-4">
+        <div class="absolute inset-0 bg-slate-900/70 backdrop-blur-sm" @click="showDeleteConfirmModal = false"></div>
+        <div class="relative bg-white rounded-3xl w-full max-w-lg p-8 shadow-2xl animate-in fade-in zoom-in-95 duration-200 border border-red-50">
+          <h3 class="text-2xl font-black text-slate-800 mb-2">스터디 해체</h3>
+          <p class="text-sm text-slate-500 leading-relaxed mb-8 break-keep">
+            <span class="block">정말 <span class="bg-red-50 text-red-600 px-1.5 py-0.5 rounded font-bold underline decoration-2 underline-offset-4">{{ study.name }}</span> 스터디를 해체하시겠습니까?</span>
+            <span class="block">이 작업은 되돌릴 수 없으며, 모든 미션과 기록이 영구적으로 삭제됩니다.</span>
+          </p>
+          
+          <div class="mb-8">
+            <label class="block text-xs font-bold text-slate-400 mb-3 uppercase tracking-widest">스터디 이름을 입력하세요</label>
+            <input 
+              v-model="deleteInput"
+              type="text"
+              class="w-full bg-slate-50 border-2 border-slate-100 rounded-2xl px-5 py-4 font-black text-slate-800 focus:outline-none focus:border-red-500 focus:bg-white transition-all placeholder:text-slate-200"
+              :placeholder="study.name"
+            />
+          </div>
+
+          <div class="flex gap-4">
+            <button 
+              @click="showDeleteConfirmModal = false"
+              class="flex-1 py-4 rounded-2xl font-bold text-slate-500 border border-slate-200 hover:bg-slate-50 transition-colors"
+            >
+              취소
+            </button>
+            <button 
+              @click="handleConfirmDelete"
+              :disabled="deleteInput !== study.name"
+              class="flex-1 py-4 rounded-2xl font-bold text-white bg-red-500 hover:bg-red-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-red-200"
+            >
+              해체하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<style scoped>
+.custom-scrollbar::-webkit-scrollbar {
+  width: 4px;
+}
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #e2e8f0;
+  border-radius: 10px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #cbd5e1;
+}
+
+/* Base Decoration Classes (from project CSS if available) */
+.text-brand-gradient {
+  background: linear-gradient(to right, #6366f1, #06b6d4);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+</style>

--- a/frontend/src/views/study/StudyManageView.vue
+++ b/frontend/src/views/study/StudyManageView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { studyApi } from '@/api/study';
 import { useAuth } from '@/composables/useAuth';
@@ -7,7 +7,6 @@ import {
   Settings, Users, Crown, Trash2, UserCheck, 
   ChevronLeft, Loader2, Save, AlertTriangle, X, Check
 } from 'lucide-vue-next';
-import BaseIconBadge from '@/components/common/BaseIconBadge.vue';
 
 const router = useRouter();
 const { user, refresh } = useAuth();
@@ -46,6 +45,14 @@ onMounted(async () => {
     if (study.value.creatorId !== user.value.id && user.value.role !== 'ROLE_ADMIN') {
       alert("스터디장만 접근 가능합니다.");
       router.replace('/dashboard');
+      return;
+    }
+
+    // Block personal study management
+    if (study.value.studyType === 'PERSONAL') {
+      alert("개인 연구실은 관리할 수 없습니다.");
+      router.replace('/dashboard');
+      return;
     }
   } catch (e) {
     console.error("Failed to load study info", e);
@@ -98,6 +105,7 @@ const handleDelegate = async () => {
   
   try {
     await studyApi.delegateLeader(study.value.id, selectedMemberId.value);
+    await refresh();
     alert("스터디장이 변경되었습니다.");
     router.replace('/profile');
   } catch(e) {
@@ -118,6 +126,7 @@ const handleConfirmDelete = async () => {
   
   try {
     await studyApi.deleteStudy(study.value.id);
+    await refresh();
     alert("스터디가 해체되었습니다.");
     router.replace('/training/roadmap');
   } catch (e) {

--- a/frontend/src/views/user/ProfileView.vue
+++ b/frontend/src/views/user/ProfileView.vue
@@ -13,70 +13,12 @@ import TroubleshootingModal from '@/components/common/TroubleshootingModal.vue';
 const router = useRouter();
 const { refresh, user, logout } = useAuth();
 
+const goToStudyManage = () => {
+    router.push('/study/manage');
+};
+
 // 스터디 메뉴 상태
 const showStudyMenu = ref(false);
-
-// 위임 모달 상태
-const showDelegateModal = ref(false);
-const memberList = ref([]);
-const loadingMembers = ref(false);
-const selectedMemberId = ref(null);
-
-const openDelegateModal = async () => {
-    showDelegateModal.value = true;
-    loadingMembers.value = true;
-    selectedMemberId.value = null; // reset selection
-    try {
-        const res = await studyApi.getMembers(userData.value.studyId);
-        // Exclude self
-        memberList.value = res.data.filter(m => m.id !== userData.value.id);
-    } catch (e) {
-        console.error(e);
-        alert("멤버 목록을 불러오지 못했습니다.");
-        showDelegateModal.value = false;
-    } finally {
-        loadingMembers.value = false;
-    }
-};
-
-const handleDelegate = async () => {
-    if (!selectedMemberId.value) return;
-    if (!confirm("정말로 스터디장 권한을 위임하시겠습니까?\n위임 후에는 일반 멤버로 전환됩니다.")) return;
-    try {
-        await studyApi.delegateLeader(userData.value.studyId, selectedMemberId.value);
-        alert("스터디장이 변경되었습니다.");
-        window.location.reload();
-    } catch(e) {
-        console.error(e);
-        alert("위임에 실패했습니다.");
-    }
-};
-
-// 삭제 모달 상태
-const showDeleteConfirmModal = ref(false);
-const deleteInput = ref('');
-
-const openDeleteModal = () => {
-    if (userData.value.studyType === 'PERSONAL') {
-        alert("임시 스터디(Personal Study)는 직접 삭제할 수 없습니다.\n새로운 스터디를 생성하거나 다른 스터디에 가입하면 자동으로 정리됩니다.");
-        return;
-    }
-    deleteInput.value = '';
-    showDeleteConfirmModal.value = true;
-};
-
-const handleConfirmDelete = async () => {
-    if (deleteInput.value !== studyName.value) return;
-    
-    try {
-        await studyApi.deleteStudy(userData.value.studyId);
-        alert("스터디가 해체되었습니다.");
-        window.location.reload();
-    } catch (e) {
-        console.error(e);
-        alert(e.response?.data?.message || "해체에 실패했습니다.");
-    }
-};
 
 // ... (userData definition)
 
@@ -270,6 +212,7 @@ const handleDelete = async () => {
     }
 };
 
+// 스터디 탈퇴는 남겨둠 (일반 멤버용)
 const handleLeaveStudy = async () => {
     if (!confirm("정말로 스터디를 탈퇴하시겠습니까?")) return;
     try {
@@ -279,26 +222,6 @@ const handleLeaveStudy = async () => {
     } catch (e) {
         console.error(e);
         alert(e.response?.data?.message || "탈퇴에 실패했습니다.");
-    }
-};
-
-const handleDeleteStudy = async () => {
-    if (userData.value.studyType === 'PERSONAL') {
-        alert("임시 스터디(Personal Study)는 직접 삭제할 수 없습니다.\n새로운 스터디를 생성하거나 다른 스터디에 가입하면 자동으로 정리됩니다.");
-        return;
-    }
-
-    if (!confirm("정말로 스터디를 해체하시겠습니까?\n\n이 작업은 되돌릴 수 없으며, 모든 미션과 기록이 삭제됩니다.")) return;
-    // 이중 확인 (안전을 위해)
-    if (!confirm("모든 스터디원이 탈퇴 처리되며, 스터디 정보가 영구적으로 삭제됩니다. 계속하시겠습니까?")) return;
-    
-    try {
-        await studyApi.deleteStudy(userData.value.studyId);
-        alert("스터디가 해체되었습니다.");
-        window.location.reload();
-    } catch (e) {
-        console.error(e);
-        alert(e.response?.data?.message || "해체에 실패했습니다.");
     }
 };
 
@@ -444,18 +367,11 @@ const showFaq = ref(false);
                             <!-- 스터디장 전용 -->
                             <template v-if="userData.isStudyLeader">
                                 <button 
-                                    @click="openDelegateModal(); showStudyMenu = false"
+                                    @click="goToStudyManage(); showStudyMenu = false"
                                     class="w-full text-left px-3 py-2.5 text-sm font-bold text-slate-600 hover:bg-slate-50 hover:text-slate-800 rounded-lg transition-colors flex items-center gap-2"
                                 >
-                                    <UserCheck :size="16" />
-                                    스터디장 위임
-                                </button>
-                                <button 
-                                    @click="openDeleteModal(); showStudyMenu = false"
-                                    class="w-full text-left px-3 py-2.5 text-sm font-bold text-rose-500 hover:bg-rose-50 rounded-lg transition-colors flex items-center gap-2"
-                                >
-                                    <Trash2 :size="16" />
-                                    스터디 해체
+                                    <Settings :size="16" />
+                                    스터디 설정 및 관리
                                 </button>
                             </template>
 
@@ -535,103 +451,7 @@ const showFaq = ref(false);
         <!-- ... (skipped for brevity) ... -->
         
         <!-- (At the end of template before styles) -->
-        <!-- Delegation Modal -->
         <Teleport to="body">
-            <div v-if="showDelegateModal" class="fixed inset-0 z-[9999] flex items-center justify-center p-4">
-                <div class="absolute inset-0 bg-slate-900/40 backdrop-blur-sm" @click="showDelegateModal = false"></div>
-                <!-- ... Content ... -->
-                <div class="relative bg-white rounded-3xl w-full max-w-md p-6 shadow-2xl animate-in fade-in zoom-in-95 duration-200">
-                    <h3 class="text-xl font-bold text-slate-800 mb-2">스터디장 위임</h3>
-                    <p class="text-sm text-slate-500 mb-6">새로운 스터디장을 선택해주세요.</p>
-                    
-                    <div v-if="loadingMembers" class="py-8 flex justify-center">
-                        <Loader2 class="animate-spin text-brand-500" :size="32"/>
-                    </div>
-                    
-                    <div v-else-if="memberList.length === 0" class="py-10 text-center text-slate-400 font-bold bg-slate-50 rounded-2xl">
-                        위임할 수 있는 다른 멤버가 없습니다.<br>
-                        <span class="text-xs font-normal mt-1 block">혼자라면 스터디 삭제만 가능합니다.</span>
-                    </div>
-
-                    <div v-else class="space-y-2 max-h-[300px] overflow-y-auto mb-6 custom-scrollbar">
-                        <label 
-                            v-for="member in memberList" 
-                            :key="member.id"
-                            class="flex items-center gap-3 p-3 rounded-xl border-2 cursor-pointer transition-all"
-                            :class="selectedMemberId === member.id ? 'border-brand-500 bg-brand-50' : 'border-slate-100 hover:border-slate-300'"
-                        >
-                            <input type="radio" :value="member.id" v-model="selectedMemberId" class="hidden">
-                            <img :src="member.avatarUrl || '/images/profiles/default-profile.png'" class="w-10 h-10 rounded-full bg-slate-200 object-cover" />
-                            <div class="flex-1">
-                                <div class="font-bold text-slate-700">{{ member.username }}</div>
-                                <div class="text-xs text-slate-400">Tier: {{ member.solvedacTier }}</div>
-                            </div>
-                            <div v-if="selectedMemberId === member.id" class="text-brand-600">
-                                <Crown :size="20" fill="currentColor" />
-                            </div>
-                        </label>
-                    </div>
-
-                    <div class="flex gap-3">
-                        <button 
-                            @click="showDelegateModal = false"
-                            class="flex-1 py-3.5 rounded-xl font-bold text-slate-500 hover:bg-slate-100 transition-colors"
-                        >
-                            취소
-                        </button>
-                        <button 
-                            @click="handleDelegate"
-                            :disabled="!selectedMemberId"
-                            class="flex-1 py-3.5 rounded-xl font-bold text-white bg-brand-500 hover:bg-brand-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-brand-500/30"
-                        >
-                            위임하기
-                        </button>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Delete Confirmation Modal -->
-            <div v-if="showDeleteConfirmModal" class="fixed inset-0 z-[9999] flex items-center justify-center p-4">
-                <div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" @click="showDeleteConfirmModal = false"></div>
-                
-                <div class="relative bg-white rounded-3xl w-full max-w-md p-6 shadow-2xl animate-in fade-in zoom-in-95 duration-200 border-2 border-slate-100">
-                    <div class="mb-4">
-                        <h3 class="text-xl font-black text-slate-800 mb-2">스터디 삭제</h3>
-                        <p class="text-sm text-slate-500 leading-relaxed">
-                            정말 <span class="text-slate-800 font-bold">'{{ studyName }}'</span> 스터디를 삭제하시겠습니까?<br>
-                            이 작업은 되돌릴 수 없으며, 모든 미션과 기록이 영구적으로 삭제됩니다.
-                        </p>
-                    </div>
-                    
-                    <div class="mb-6">
-                        <label class="block text-xs font-bold text-slate-400 mb-2 uppercase">스터디 이름을 입력하세요</label>
-                        <input 
-                            v-model="deleteInput"
-                            type="text"
-                            class="w-full bg-slate-50 border-2 border-slate-200 rounded-xl px-4 py-3 font-bold text-slate-700 focus:outline-none focus:border-rose-500 focus:bg-white transition-all placeholder:text-slate-300"
-                            :placeholder="studyName"
-                        />
-                    </div>
-
-                    <div class="flex gap-3">
-                        <button 
-                            @click="showDeleteConfirmModal = false"
-                            class="flex-1 py-3.5 rounded-xl font-bold text-slate-500 hover:bg-slate-100 transition-colors"
-                        >
-                            취소
-                        </button>
-                        <button 
-                            @click="handleConfirmDelete"
-                            :disabled="deleteInput !== studyName"
-                            class="flex-1 py-3.5 rounded-xl font-bold text-white bg-rose-500 hover:bg-rose-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-rose-500/30"
-                        >
-                            스터디 삭제
-                        </button>
-                    </div>
-                </div>
-            </div>
-
-
             <!-- Decoration Select Modal -->
             <div v-if="showDecorationModal" class="fixed inset-0 z-[9999] flex items-center justify-center p-4">
                 <div class="absolute inset-0 bg-slate-900/40 backdrop-blur-sm" @click="showDecorationModal = false"></div>

--- a/frontend/src/views/user/ProfileView.vue
+++ b/frontend/src/views/user/ProfileView.vue
@@ -6,12 +6,12 @@ import { studyApi } from '@/api/study';
 import { shopApi } from '@/api/shop';
 import { useAuth } from '@/composables/useAuth';
 import { onboardingApi } from '@/api/onboarding';
-import { Settings, LogOut, Github, Award, Users, Crown, RotateCcw, Loader2, HelpCircle, Zap as ZapIcon, Copy, Trash2, UserCheck, MoreVertical, AlertTriangle, ChevronDown, Palette, Check, Sparkles, X } from 'lucide-vue-next';
+import { Settings, LogOut, Github, Award, Users, Crown, RotateCcw, Loader2, HelpCircle, Zap as ZapIcon, Copy, MoreVertical, AlertTriangle, ChevronDown, Palette, Check, Sparkles, X } from 'lucide-vue-next';
 import BaseIconBadge from '@/components/common/BaseIconBadge.vue';
 import TroubleshootingModal from '@/components/common/TroubleshootingModal.vue';
 
 const router = useRouter();
-const { refresh, user, logout } = useAuth();
+const { logout } = useAuth();
 
 const goToStudyManage = () => {
     router.push('/study/manage');
@@ -365,7 +365,7 @@ const showFaq = ref(false);
                         <div v-if="showStudyMenu" class="absolute right-0 top-full mt-2 w-48 bg-white rounded-xl shadow-xl border border-slate-100 p-1.5 z-20 animate-in fade-in zoom-in-95 duration-200 origin-top-right flex flex-col gap-1">
                             
                             <!-- 스터디장 전용 -->
-                            <template v-if="userData.isStudyLeader">
+                            <template v-if="userData.isStudyLeader && userData.studyType !== 'PERSONAL'">
                                 <button 
                                     @click="goToStudyManage(); showStudyMenu = false"
                                     class="w-full text-left px-3 py-2.5 text-sm font-bold text-slate-600 hover:bg-slate-50 hover:text-slate-800 rounded-lg transition-colors flex items-center gap-2"


### PR DESCRIPTION
## 🚀 작업 배경

문제 풀이 직후 GitHub 웹훅 워커에서 AI 코드 분석을 자동 생성하던 구조는 실제 조회하지 않는 제출까지 분석을 수행해 비용과 처리 시간을 낭비하고 있었습니다.  
또한 자동 분석이 실패한 경우 기존 UI 흐름에서는 해당 기록이 다시 분석되지 않을 수 있었고, 관리자 관전 모드나 같은 스터디 내 공유 대시보드처럼 타인의 풀이를 보는 흐름과 AI 분석 권한 정책도 맞지 않았습니다.

이번 작업은 AI 코드 분석을 사용자가 상세 기록을 열 때 생성하는 온디맨드 방식으로 전환하고, 그에 맞춰 대시보드 사이드바/권한 처리/UI 문구를 정리하기 위해 진행했습니다.

---

## 🛠️ 주요 변경 사항

- GitHub 웹훅 워커에서 제출 후 자동 AI 분석 실행 로직 제거
- `POST /api/ai/review`를 `algorithmRecordId` 기반 온디맨드 분석 생성 흐름으로 전환
- `GET /api/ai/review/{algorithmRecordId}` 조회 시 인증 및 권한 검증 적용
- AI 분석 권한을 `본인 / 같은 스터디 멤버 / 관리자`까지 허용하도록 확장
- 반례만 먼저 저장된 row가 있어도 실제 코드 분석이 없으면 다시 분석 생성되도록 보완
- 분석 재생성 시 기존 반례 데이터가 유지되도록 처리
- 대시보드 우측 `AnalysisSidebar`에서 기록 클릭 시
  - 기존 분석 조회
  - 없거나 불완전하면 분석 생성
  - 로딩 / 오류 / 재시도 상태 표시
- 반례 탭과 튜터 탭은 분석 준비 전에는 사용하지 못하도록 로딩 상태 중심으로 정리
- 카드에서 생성된 분석 결과를 대시보드 목록 상태에 병합해 이후 동일 기록에 즉시 반영되도록 수정
- `DashboardRecordCard` 호버 미리보기 제거 후 카드 UI와 문구를 더 단순한 형태로 정리
- 관련 안내 문구와 사용자 노출 메시지를 한국어 기준으로 다듬음
- 소스 파일 줄바꿈 정책(`.gitattributes`) 정리

---

## 🔗 관련 이슈

- 없음