### PR TITLE
fix(dashboard): 분석 완료 후 사이드바 상태를 즉시 반영

### DIFF
--- a/frontend/src/views/dashboard/AnalysisSidebar.vue
+++ b/frontend/src/views/dashboard/AnalysisSidebar.vue
@@ -451,6 +451,10 @@ const record = computed(() => mergedRecord.value);
 watch(
     () => props.record,
     async (newRecord) => {
+        const currentRecordId = mergedRecord.value?.id;
+        const isSameRecord = currentRecordId != null && currentRecordId === newRecord?.id;
+        const preservedAnalysis = isSameRecord ? mapAnalysisToRecord(mergedRecord.value || {}) : {};
+
         activeTab.value = 'overview';
         tutorMessages.value = [];
         showTrace.value = false;
@@ -464,7 +468,10 @@ watch(
             return;
         }
 
-        mergedRecord.value = { ...newRecord };
+        mergedRecord.value = {
+            ...newRecord,
+            ...(hasExistingAnalysis(newRecord) ? {} : preservedAnalysis)
+        };
         if (newRecord.counterExampleInput) {
             aiData.value = {
                 input: newRecord.counterExampleInput,
@@ -476,7 +483,7 @@ watch(
             aiData.value = null;
         }
 
-        if (hasExistingAnalysis(newRecord)) {
+        if (hasExistingAnalysis(mergedRecord.value)) {
             analysisStatus.value = 'ready';
             return;
         }
@@ -522,6 +529,15 @@ const applyAnalysisToRecord = (analysis) => {
     return nextRecord;
 };
 
+const finalizeAnalysis = (analysis) => {
+    const nextRecord = applyAnalysisToRecord(analysis);
+    if (hasExistingAnalysis(nextRecord)) {
+        analysisStatus.value = 'ready';
+        return true;
+    }
+    return false;
+};
+
 const ensureAnalysisLoaded = async ({ force = false } = {}) => {
     if (!record.value?.id) return;
     const requestId = ++currentAnalysisRequestId.value;
@@ -546,8 +562,14 @@ const ensureAnalysisLoaded = async ({ force = false } = {}) => {
         }
 
         if (requestId !== currentAnalysisRequestId.value) return;
-        applyAnalysisToRecord(analysis);
-        analysisStatus.value = 'ready';
+        if (!finalizeAnalysis(analysis)) {
+            const latest = await aiApi.getAnalysisResult(record.value.id);
+            if (requestId !== currentAnalysisRequestId.value) return;
+            if (!finalizeAnalysis(latest?.data ?? null)) {
+                analysisError.value = '분석 결과를 불러오지 못했습니다.';
+                analysisStatus.value = 'error';
+            }
+        }
     } catch (error) {
         if (requestId !== currentAnalysisRequestId.value) return;
 
@@ -557,8 +579,14 @@ const ensureAnalysisLoaded = async ({ force = false } = {}) => {
                     algorithmRecordId: record.value.id
                 });
                 if (requestId !== currentAnalysisRequestId.value) return;
-                applyAnalysisToRecord(created?.data || {});
-                analysisStatus.value = 'ready';
+                if (!finalizeAnalysis(created?.data || null)) {
+                    const latest = await aiApi.getAnalysisResult(record.value.id);
+                    if (requestId !== currentAnalysisRequestId.value) return;
+                    if (!finalizeAnalysis(latest?.data ?? null)) {
+                        analysisError.value = '분석 결과를 불러오지 못했습니다.';
+                        analysisStatus.value = 'error';
+                    }
+                }
                 return;
             } catch (createError) {
                 analysisError.value = createError?.response?.data?.message || '분석 생성 요청에 실패했습니다.';


### PR DESCRIPTION
## 🚀 작업 배경

AI 코드 분석을 온디맨드 방식으로 전환한 이후, 분석 요청 자체는 정상적으로 완료되어도 우측 분석 사이드바가 로딩 상태를 유지하거나 기존 레코드 데이터로 다시 덮여 분석 결과가 즉시 보이지 않는 문제가 있었습니다.

특히 같은 레코드를 부모 컴포넌트가 다시 전달하는 과정에서, 사이드바가 방금 받은 분석 데이터를 잃고 다시 “분석이 없는 상태”처럼 보일 수 있어 사용자 입장에서는 분석이 끝났는데도 화면이 갱신되지 않는 것처럼 보였습니다.

이번 작업은 분석 완료 직후 사이드바가 즉시 최신 결과를 반영하고, 로딩 상태를 정상적으로 종료하도록 보완하기 위해 진행했습니다.

---

## 🛠️ 주요 변경 사항

- `AnalysisSidebar`에서 동일 레코드 재렌더링 시 기존에 반영된 분석 데이터를 보존하도록 수정
- 분석 생성 응답이 왔더라도 실제 분석 필드가 비어 있으면 최신 결과를 한 번 더 조회하도록 보완
- 분석 데이터가 실제로 채워진 경우에만 `loading -> ready` 상태 전환이 일어나도록 수정
- 부모 컴포넌트가 이전 레코드 상태를 다시 내려줘도 사이드바가 방금 생성된 분석 결과를 잃지 않도록 처리
- 프론트 빌드 기준 동작 검증 완료

---

## 🔗 관련 이슈

- 없음